### PR TITLE
docs: consolidate docs and add YAML frontmatter indexes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ groundskeeper/           # Python package (the library + CLI)
   protocols.py           # Protocol interfaces (SkillStore, AgentRunner, CIProvider)
 tests/                   # Mirrors source layout; e2e/ has installed-CLI tests
 .groundskeeper/          # User config: config.yml + skills/
-ai_agent_docs/           # Deep-reference docs for agent onboarding
+docs/AGENTS.md           # Agent routing index for docs/
 docs/                    # MkDocs Material site
 docker/                  # Dev container setup
 mise.toml                # Task runner config (all commands below)
@@ -83,21 +83,33 @@ Format: YAML frontmatter (`name`, `description`, `triggers`, `allowed-tools`, `t
 - Skill names must be kebab-case (validated by parser regex)
 - Skill resolution order: local → external (--skill-path) → builtin (first-match wins)
 - `ClaudeCodeRunner` passes `--allowedTools` from skill frontmatter (or workflow override) and parses JSON output
-- Workflows in `.groundskeeper/config.yml` support per-step and workflow-level `allowed-tools` overrides (see `ai_agent_docs/config-and-skills.md`)
+- Workflows in `.groundskeeper/config.yml` support per-step and workflow-level `allowed-tools` overrides (see `docs/config-and-skills.md`)
 - Multi-skill CI workflows generate a single GitHub Actions file with chained jobs (stages run in parallel within, sequential across)
 - Parallel groups in workflows auto-parallelize locally only when all skills are read-only; use `--parallel` to force
 - `--yolo` flag skips all permission checks (`--dangerously-skip-permissions`)
 - `pytest` excludes `e2e` marker by default (`addopts = "-m 'not e2e'"`)
 - ty is strict: warnings are errors
 
-## Reference Docs
+## Task-Specific Docs
 
-Cross-cutting docs in `ai_agent_docs/` (load as needed):
-- `ai_agent_docs/config-and-skills.md` — config.yml format, skill frontmatter spec, allowed-tools precedence
-- `ai_agent_docs/architecture.md` — ports-and-adapters flow, domain model relationships, execution pipeline
+### Cross-cutting docs in `docs/`
 
-Authoritative sources:
-- `docs/reference/skills.md` — user-facing skill authoring guide
-- `docs/reference/cli.md` — CLI reference
-- `groundskeeper/domain/parser.py` — authoritative parsing logic for SKILL.md
-- `groundskeeper/domain/config.py` — config loading, workflow/step model, tool precedence logic
+| Doc | Topic |
+|-----|-------|
+| `docs/AGENTS.md` | Agent routing index for all docs |
+| `docs/architecture.md` | Ports-and-adapters flow, domain model relationships, execution pipeline |
+| `docs/config-and-skills.md` | config.yml format, skill frontmatter spec, allowed-tools precedence |
+| `docs/future-work.md` | Planned features: worktree isolation, additional agent runners |
+
+### Reference
+
+| Doc | Topic |
+|-----|-------|
+| `docs/reference/skills.md` | User-facing skill authoring guide |
+| `docs/reference/cli.md` | CLI reference |
+| `docs/reference/api.md` | Auto-generated API docs |
+
+## Key References
+
+- `groundskeeper/domain/parser.py` -- authoritative parsing logic for SKILL.md
+- `groundskeeper/domain/config.py` -- config loading, workflow/step model, tool precedence logic

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,26 @@
+# docs/ Index
+
+Agent routing index for Groundskeeper documentation. Load by doc type as needed.
+
+## Tutorials
+
+| Doc | Description |
+|-----|-------------|
+| `getting-started.md` | Installation, project init, skill creation, workflow commands |
+
+## Explanation
+
+| Doc | Description |
+|-----|-------------|
+| `architecture.md` | Ports-and-adapters design, domain models, execution and CI generation flows |
+| `config-and-skills.md` | config.yml format, allowed-tools precedence, SKILL.md spec, resolution order |
+| `future-work.md` | Planned features: worktree isolation, additional agent runners |
+| `index.md` | Project overview, quick start, core concepts |
+
+## Reference
+
+| Doc | Description |
+|-----|-------------|
+| `reference/cli.md` | All gk CLI commands with options and usage |
+| `reference/skills.md` | Skill format spec, frontmatter fields, built-in skills |
+| `reference/api.md` | Auto-generated API docs for domain models, parser, errors |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,17 @@
+---
+id: architecture
+title: Architecture Deep Reference
+description: >
+  Ports-and-adapters design, domain models, execution flow,
+  and CI generation pipeline for the Groundskeeper system.
+index:
+  - id: ports-and-adapters
+  - id: domain-models-groundskeeperdomainmodelspy
+  - id: workflow-models-groundskeeperdomainconfigpy
+  - id: execution-flow
+  - id: ci-generation-flow
+---
+
 # Architecture Deep Reference
 
 ## Ports and Adapters

--- a/docs/config-and-skills.md
+++ b/docs/config-and-skills.md
@@ -1,3 +1,15 @@
+---
+id: config-and-skills
+title: Config & Skills Deep Reference
+description: >
+  config.yml format, allowed-tools precedence, SKILL.md frontmatter spec,
+  directory layout, $ARGUMENTS substitution, and skill resolution order.
+index:
+  - id: groundskeeperconfigyml
+  - id: skillmd-format
+  - id: skill-resolution-order
+---
+
 # Config & Skills Deep Reference
 
 ## .groundskeeper/config.yml

--- a/docs/future-work.md
+++ b/docs/future-work.md
@@ -1,3 +1,13 @@
+---
+id: future-work
+title: Future Work
+description: >
+  Planned features: worktree-isolated parallel execution and
+  additional agent runner implementations (Codex, Agent SDK, Jules).
+index:
+  - id: additional-agent-runners
+---
+
 # Future Work
 
 ## Worktree-isolated parallel execution (`--parallel --isolate`)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,17 @@
+---
+id: getting-started
+title: Getting Started
+description: >
+  Installation, project initialization, configuration, skill creation,
+  and core workflow commands for Groundskeeper.
+index:
+  - id: installation
+  - id: initialize-a-project
+  - id: configuration
+  - id: creating-a-skill
+  - id: workflow-commands
+---
+
 # Getting Started
 
 ## Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,16 @@
+---
+id: index
+title: Groundskeeper
+description: >
+  Project homepage: what Groundskeeper is, quick start commands,
+  core concepts, and how skills-to-CI workflow operates.
+index:
+  - id: what-is-groundskeeper
+  - id: quick-start
+  - id: concepts
+  - id: how-it-works
+---
+
 # Groundskeeper
 
 Script AI agents to run on your PRs.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,3 +1,14 @@
+---
+id: api-reference
+title: API Reference
+description: >
+  Auto-generated API docs for domain models, parser, and error types.
+index:
+  - id: domain-models
+  - id: parser
+  - id: errors
+---
+
 # API Reference
 
 ## Domain Models

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,3 +1,19 @@
+---
+id: cli-reference
+title: CLI Reference
+description: >
+  Complete reference for all gk CLI commands: init, list, show, run,
+  check, generate, and render with options and usage examples.
+index:
+  - id: gk-init
+  - id: gk-list
+  - id: gk-show-name
+  - id: gk-run-name
+  - id: gk-check-name
+  - id: gk-generate
+  - id: gk-render-name
+---
+
 # CLI Reference
 
 ## `gk init`

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -1,3 +1,15 @@
+---
+id: skills-reference
+title: Skills Reference
+description: >
+  Skill format specification: SKILL.md structure, frontmatter fields,
+  directory layout, resolution order, and built-in skill descriptions.
+index:
+  - id: skill-format
+  - id: resolution-order
+  - id: built-in-skills
+---
+
 # Skills Reference
 
 ## Skill Format


### PR DESCRIPTION
## Summary
- Move `ai_agent_docs/` contents into `docs/` (architecture.md, config-and-skills.md)
- Rename `docs/FUTURE_WORK.md` to `docs/future-work.md` for consistent kebab-case naming
- Add YAML frontmatter with `id`, `title`, `description`, and `index` (section list) to all doc files for machine-readable progressive disclosure
- Create `docs/AGENTS.md` as an agent routing index categorizing docs by type (tutorials, explanation, reference)
- Update root `AGENTS.md` references from `ai_agent_docs/` to `docs/` and restructure the task-specific docs section as tables

## Test plan
- [x] `mise run check` passes (lint, format, ty, 133 tests)
- [ ] CI checks pass
- [ ] Docs build succeeds (`mise run docs:build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)