### PR TITLE
Stream factory progress and expose sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,14 @@ issue bodies. Set a scheduler's working directory to the repository containing
 `.groundskeeper/config.yml`, or pass `gk automation --config PATH ...`.
 
 Each issue maps to a deterministic UUIDv5 Pi session and stable run name. Pi
-runs have a configurable positive timeout (`timeout-seconds`, default 7,200
+output streams to Groundskeeper's stderr for live scheduler logs while the final
+versioned JSON result remains on stdout. Review and blocked results include the
+session ID, name, and generic `pi --session ID` resume command; GitHub transition
+comments preserve the same handoff metadata. Streaming Pi automations require a
+POSIX host so Groundskeeper can terminate the complete process group before
+releasing repository locks; unsupported hosts fail before starting Pi.
+
+Pi runs have a configurable positive timeout (`timeout-seconds`, default 7,200
 seconds); GitHub CLI operations have fixed 30-second timeouts. After a timeout,
 Groundskeeper reconciles the same accepted GitHub result first; without one, it
 blocks the claimed issue with the command error and releases the host lock for retry.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,12 +84,16 @@ automation config
   → acquire stable host-state lock for normalized repository identity
   → reconcile running issues before selecting ready work
   → claim at most one trusted issue
-  → render configured skill + task/recovery/policy context
+  → render configured skill + task/recovery/policy/session context
+  → require POSIX process-group isolation
   → run Pi in a deterministic session with a bounded process group
+      combined child output → Groundskeeper stderr for live logs
+      buffered output → PR URL parsing and failure detail
   → reconcile GitHub as the durable result authority
       exact closing open draft PR → review
       non-draft, closed, or merged closing PR → blocked policy violation
       no accepted PR + worker failure → blocked worker error
+  → expose session id, stable name, and resume command in JSON + issue comment
 ```
 
 The workflow instructions belong to the configured skill; the Pi adapter knows

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -36,7 +36,13 @@ selected-skill provenance (name, source kind, and path, never the prompt body).
 repository path, and the fixed draft-only/never-merge policy without contacting
 GitHub or starting work. `tick` runs one bounded reconciliation pass. Dry-run
 selects and reports eligible work without labels, comments, or worker launch.
-Its compact output omits issue bodies.
+Its compact output omits issue bodies. Pi child output is streamed to stderr so
+scheduler logs show progress without corrupting JSON stdout. Terminal review or
+blocked results expose `session_id`, `session_name`, and `resume_command` in the
+JSON `data` object. The generic resume command uses `pi`; callers with auth
+profiles can substitute their profile wrapper, such as `pih`. Pi automation
+requires POSIX process-group isolation; unsupported hosts fail before worker
+startup rather than risk descendants surviving after lock release.
 
 Pi runner configuration accepts optional `timeout-seconds` (default: 7,200) for
 long-running tasks. GitHub CLI calls use a fixed 30-second timeout. Groundskeeper

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -41,8 +41,9 @@ scheduler logs show progress without corrupting JSON stdout. Terminal review or
 blocked results expose `session_id`, `session_name`, and `resume_command` in the
 JSON `data` object. The generic resume command uses `pi`; callers with auth
 profiles can substitute their profile wrapper, such as `pih`. Pi automation
-requires POSIX process-group isolation; unsupported hosts fail before worker
-startup rather than risk descendants surviving after lock release.
+requires POSIX process-group isolation; validation and live ticks reject
+unsupported hosts before tracker access, issue claim, or worker startup rather
+than risk descendants surviving after lock release.
 
 Pi runner configuration accepts optional `timeout-seconds` (default: 7,200) for
 long-running tasks. GitHub CLI calls use a fixed 30-second timeout. Groundskeeper

--- a/groundskeeper/adapters/automation_runner.py
+++ b/groundskeeper/adapters/automation_runner.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Protocol
 
 from groundskeeper.adapters.pi import PiExecutionSettings
-from groundskeeper.domain.automation import AutomationTask, WorkResult
+from groundskeeper.domain.automation import AutomationTask, SessionMetadata, WorkResult
 from groundskeeper.domain.config import AutomationPolicy, PiRunnerConfig
 from groundskeeper.domain.models import Skill
 
@@ -27,14 +27,25 @@ class AutomationSkillRenderer:
         self._skill = skill
         self._policy = policy
 
-    def render(self, task: AutomationTask, recovery: bool) -> str:
+    def render(
+        self,
+        task: AutomationTask,
+        recovery: bool,
+        settings: PiExecutionSettings,
+    ) -> str:
         """Render a skill without changing ordinary skill rendering behavior."""
         return (
-            f"{self._skill.render()}\n\n{self._context(task, recovery, self._policy)}"
+            f"{self._skill.render()}\n\n"
+            f"{self._context(task, recovery, self._policy, settings)}"
         )
 
     @staticmethod
-    def _context(task: AutomationTask, recovery: bool, policy: AutomationPolicy) -> str:
+    def _context(
+        task: AutomationTask,
+        recovery: bool,
+        policy: AutomationPolicy,
+        settings: PiExecutionSettings,
+    ) -> str:
         recovery_context = (
             "Resume the deterministic session for this task and reconcile durable state."
             if recovery
@@ -52,6 +63,9 @@ class AutomationSkillRenderer:
                 f"POLICY_CONCURRENCY: {policy.concurrency}",
                 f"POLICY_OUTPUT: {policy.output}",
                 f"POLICY_MERGE: {policy.merge}",
+                f"FACTORY_SESSION_ID: {settings.session_id}",
+                f"FACTORY_SESSION_NAME: {settings.name}",
+                f"FACTORY_RESUME_COMMAND: pi --session {settings.session_id}",
                 f"RECOVERY_CONTEXT: {recovery_context}",
             )
         )
@@ -72,14 +86,28 @@ class PiAutomationRunner:
         self._renderer = renderer
         self._config = config
 
-    def run(self, task: AutomationTask, recovery: bool = False) -> WorkResult:
+    def _settings(self, task: AutomationTask) -> PiExecutionSettings:
         identity = f"groundskeeper:{task.target_repository}:{task.external_id}"
-        settings = PiExecutionSettings(
+        return PiExecutionSettings(
             session_id=str(uuid.uuid5(uuid.NAMESPACE_URL, identity)),
             name=f"gk-{task.target_repository.replace('/', '-')}-{task.external_id}",
             approval=self._config.approval,
             timeout_seconds=self._config.timeout_seconds,
         )
+
+    def session_metadata(self, task: AutomationTask) -> SessionMetadata:
+        """Return stable session identity without starting or resuming Pi."""
+        settings = self._settings(task)
+        return SessionMetadata(
+            settings.session_id,
+            settings.name,
+            f"pi --session {settings.session_id}",
+        )
+
+    def run(self, task: AutomationTask, recovery: bool = False) -> WorkResult:
+        settings = self._settings(task)
         return self._client.run_prompt(
-            self._renderer.render(task, recovery), self._repository_path, settings
+            self._renderer.render(task, recovery, settings),
+            self._repository_path,
+            settings,
         )

--- a/groundskeeper/adapters/pi.py
+++ b/groundskeeper/adapters/pi.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import shutil
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -37,7 +38,12 @@ class PiClient:
         self, prompt: str, cwd: Path, settings: PiExecutionSettings
     ) -> WorkResult:
         """Run a rendered prompt with explicit, already-approved settings."""
-        result = self._process.run(
+        print(
+            f"[groundskeeper] pi start session={settings.session_id} name={settings.name}",
+            file=sys.stderr,
+            flush=True,
+        )
+        result = self._process.run_streaming(
             (
                 "pi",
                 "--session-id",
@@ -51,6 +57,11 @@ class PiClient:
             cwd,
             timeout=settings.timeout_seconds,
         )
+        print(
+            f"[groundskeeper] pi finish session={settings.session_id} exit={result.exit_code}",
+            file=sys.stderr,
+            flush=True,
+        )
         match = re.search(r"https://github\.com/[^\s]+/pull/\d+", result.stdout)
         return WorkResult(
             success=result.success,
@@ -58,4 +69,7 @@ class PiClient:
             error=result.stderr,
             exit_code=result.exit_code,
             pull_request_url=match.group(0) if match else None,
+            session_id=settings.session_id,
+            session_name=settings.name,
+            resume_command=f"pi --session {settings.session_id}",
         )

--- a/groundskeeper/adapters/pi.py
+++ b/groundskeeper/adapters/pi.py
@@ -34,6 +34,10 @@ class PiClient:
         """Return whether the Pi executable is discoverable without invoking it."""
         return shutil.which("pi") is not None
 
+    def supports_automation(self) -> bool:
+        """Return whether the host can safely contain Pi's descendant processes."""
+        return self._process.supports_streaming_process_groups()
+
     def run_prompt(
         self, prompt: str, cwd: Path, settings: PiExecutionSettings
     ) -> WorkResult:

--- a/groundskeeper/adapters/process.py
+++ b/groundskeeper/adapters/process.py
@@ -47,6 +47,10 @@ def _drain_process_output(
 class ProcessClient:
     """Executes commands without shell interpolation."""
 
+    def supports_streaming_process_groups(self) -> bool:
+        """Return whether streaming workers can be terminated as one process group."""
+        return STREAMING_PROCESS_GROUPS_SUPPORTED
+
     def run(
         self, argv: tuple[str, ...], cwd: Path, timeout: int | None = None
     ) -> CommandResult:

--- a/groundskeeper/adapters/process.py
+++ b/groundskeeper/adapters/process.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 import os
 import signal
 import subprocess
+import sys
+import threading
+import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TextIO
 
 PROCESS_TERMINATION_GRACE_SECONDS = 5
+PROCESS_ERROR_TAIL_CHARS = 8_000
+STREAMING_PROCESS_GROUPS_SUPPORTED = os.name == "posix"
 
 
 @dataclass(frozen=True)
@@ -24,6 +30,18 @@ class CommandResult:
     @property
     def success(self) -> bool:
         return self.exit_code == 0
+
+
+def _drain_process_output(
+    process: subprocess.Popen[str], destination: TextIO, chunks: list[str]
+) -> None:
+    """Copy merged process output to both an in-memory buffer and a live stream."""
+    if process.stdout is None:
+        return
+    for chunk in process.stdout:
+        chunks.append(chunk)
+        destination.write(chunk)
+        destination.flush()
 
 
 class ProcessClient:
@@ -65,8 +83,82 @@ class ProcessClient:
             stderr=stderr,
         )
 
+    def run_streaming(
+        self,
+        argv: tuple[str, ...],
+        cwd: Path,
+        timeout: int | None = None,
+        stream: TextIO | None = None,
+    ) -> CommandResult:
+        """Tee combined child output to a stream while preserving it for parsing."""
+        if not STREAMING_PROCESS_GROUPS_SUPPORTED:
+            return CommandResult(
+                argv,
+                cwd,
+                126,
+                "",
+                "streaming automation requires POSIX process-group isolation",
+            )
+        destination = stream or sys.stderr
+        try:
+            process = subprocess.Popen(
+                argv,
+                cwd=cwd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                start_new_session=os.name == "posix",
+            )
+        except FileNotFoundError:
+            return CommandResult(argv, cwd, 127, "", f"command not found: {argv[0]}")
+        except OSError as error:
+            return CommandResult(
+                argv, cwd, 126, "", f"could not run {argv[0]}: {error}"
+            )
+
+        chunks: list[str] = []
+        reader = threading.Thread(
+            target=_drain_process_output,
+            args=(process, destination, chunks),
+            daemon=True,
+        )
+        reader.start()
+        deadline = time.monotonic() + timeout if timeout is not None else None
+        timed_out = False
+        try:
+            process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            self._terminate_process_tree(process, drain_pipes=False)
+
+        if not timed_out:
+            if deadline is None:
+                reader.join()
+            else:
+                reader.join(timeout=max(0.0, deadline - time.monotonic()))
+                if reader.is_alive():
+                    timed_out = True
+                    self._terminate_process_tree(process, drain_pipes=False)
+        if timed_out:
+            reader.join(timeout=PROCESS_TERMINATION_GRACE_SECONDS)
+        combined = "".join(chunks)
+        if timed_out:
+            detail = f" after {timeout} seconds" if timeout is not None else ""
+            error = f"command timed out{detail}: {argv[0]}"
+            return CommandResult(argv, cwd, 124, combined, error)
+        return CommandResult(
+            argv=argv,
+            cwd=cwd,
+            exit_code=process.returncode,
+            stdout=combined,
+            stderr=combined[-PROCESS_ERROR_TAIL_CHARS:] if process.returncode else "",
+        )
+
     @staticmethod
-    def _terminate_process_tree(process: subprocess.Popen[str]) -> None:
+    def _terminate_process_tree(
+        process: subprocess.Popen[str], drain_pipes: bool = True
+    ) -> None:
         """Terminate a timed-out command group, escalate if needed, then reap it."""
         if os.name == "posix":
             try:
@@ -97,4 +189,5 @@ class ProcessClient:
         except subprocess.TimeoutExpired:
             process.kill()
         finally:
-            process.communicate()
+            if drain_pipes:
+                process.communicate()

--- a/groundskeeper/automation.py
+++ b/groundskeeper/automation.py
@@ -4,12 +4,37 @@ from __future__ import annotations
 
 from groundskeeper.domain.automation import (
     AutomationTask,
+    SessionMetadata,
     TaskState,
     TickResult,
     WorkResult,
 )
 from groundskeeper.domain.config import Automation
 from groundskeeper.protocols import AutomationRunner, Tracker
+
+
+def _work_result_for_session(metadata: SessionMetadata | None) -> WorkResult:
+    """Represent known session identity when no worker process result is available."""
+    if metadata is None:
+        return WorkResult(True)
+    return WorkResult(
+        True,
+        session_id=metadata.session_id,
+        session_name=metadata.session_name,
+        resume_command=metadata.resume_command,
+    )
+
+
+def _result_detail(primary: str, result: WorkResult) -> str:
+    """Combine a terminal result with resumable Pi session metadata."""
+    lines = [primary]
+    if result.session_id:
+        lines.extend(("", f"Factory session: `{result.session_id}`"))
+    if result.session_name:
+        lines.append(f"Session name: `{result.session_name}`")
+    if result.resume_command:
+        lines.append(f"Resume: `{result.resume_command}`")
+    return "\n".join(lines)
 
 
 class AutomationService:
@@ -26,9 +51,14 @@ class AutomationService:
             except RuntimeError as error:
                 return self._block(automation.name, task, str(error))
             if existing_pr:
-                if not dry_run:
-                    self._tracker.transition(task, TaskState.REVIEW, existing_pr)
-                return TickResult(automation.name, "review", task, existing_pr)
+                if dry_run:
+                    return TickResult(automation.name, "review", task, existing_pr)
+                return self._review(
+                    automation.name,
+                    task,
+                    existing_pr,
+                    _work_result_for_session(self._runner.session_metadata(task)),
+                )
             if dry_run:
                 return TickResult(automation.name, "would-resume", task)
             return self._finish(
@@ -48,8 +78,12 @@ class AutomationService:
         except RuntimeError as error:
             return self._block(automation.name, claim.task, str(error))
         if existing_pr:
-            self._tracker.transition(claim.task, TaskState.REVIEW, existing_pr)
-            return TickResult(automation.name, "review", claim.task, existing_pr)
+            return self._review(
+                automation.name,
+                claim.task,
+                existing_pr,
+                _work_result_for_session(self._runner.session_metadata(claim.task)),
+            )
         result = self._runner.run(claim.task)
         return self._finish(automation.name, claim.task, result)
 
@@ -60,22 +94,60 @@ class AutomationService:
         try:
             pr_url = self._tracker.find_pull_request(task)
             if pr_url:
-                self._tracker.transition(task, TaskState.REVIEW, pr_url)
-                return TickResult(name, "review", task, pr_url)
+                return self._review(name, task, pr_url, result)
             violation = self._tracker.find_policy_violation(task)
         except RuntimeError as error:
-            return self._block(name, task, str(error))
+            return self._block(name, task, str(error), result)
 
         if violation is not None:
-            return self._block(name, task, violation)
+            return self._block(name, task, violation, result)
         if not result.success:
             detail = result.error.strip() or f"worker exited {result.exit_code}"
-            return self._block(name, task, detail)
+            return self._block(name, task, detail, result)
         return self._block(
-            name, task, "Worker completed without an open draft pull request"
+            name,
+            task,
+            "Worker completed without an open draft pull request",
+            result,
         )
 
-    def _block(self, name: str, task: AutomationTask, detail: str) -> TickResult:
+    def _review(
+        self,
+        name: str,
+        task: AutomationTask,
+        pull_request_url: str,
+        result: WorkResult,
+    ) -> TickResult:
+        """Record a review transition with available session handoff metadata."""
+        detail = _result_detail(pull_request_url, result)
+        self._tracker.transition(task, TaskState.REVIEW, detail)
+        return TickResult(
+            name,
+            "review",
+            task,
+            pull_request_url,
+            detail,
+            result.session_id,
+            result.session_name,
+            result.resume_command,
+        )
+
+    def _block(
+        self,
+        name: str,
+        task: AutomationTask,
+        detail: str,
+        result: WorkResult | None = None,
+    ) -> TickResult:
         """Record an actionable terminal failure for a claimed or running task."""
-        self._tracker.transition(task, TaskState.BLOCKED, detail)
-        return TickResult(name, "blocked", task, detail=detail)
+        rendered = _result_detail(detail, result) if result is not None else detail
+        self._tracker.transition(task, TaskState.BLOCKED, rendered)
+        return TickResult(
+            name,
+            "blocked",
+            task,
+            detail=rendered,
+            session_id=result.session_id if result else None,
+            session_name=result.session_name if result else None,
+            resume_command=result.resume_command if result else None,
+        )

--- a/groundskeeper/cli/main.py
+++ b/groundskeeper/cli/main.py
@@ -458,6 +458,9 @@ def automation_tick(
         "task": task_data,
         "pull_request_url": result.pull_request_url,
         "detail": result.detail,
+        "session_id": result.session_id,
+        "session_name": result.session_name,
+        "resume_command": result.resume_command,
     }
     exit_code = {
         "no-work": 0,

--- a/groundskeeper/cli/main.py
+++ b/groundskeeper/cli/main.py
@@ -271,6 +271,11 @@ def _build_automation_runner(
         raise ConfigError(
             "Pi CLI not found. Install Pi and retry 'gk automation validate'."
         )
+    if require_available and not client.supports_automation():
+        raise ConfigError(
+            "Pi automation requires POSIX process-group isolation; "
+            "run this automation on macOS or Linux."
+        )
     return PiAutomationRunner(
         client,
         repository_path,

--- a/groundskeeper/domain/automation.py
+++ b/groundskeeper/domain/automation.py
@@ -39,6 +39,15 @@ class ClaimResult:
 
 
 @dataclass(frozen=True)
+class SessionMetadata:
+    """Stable identity needed to inspect or resume an automation session."""
+
+    session_id: str
+    session_name: str
+    resume_command: str
+
+
+@dataclass(frozen=True)
 class WorkResult:
     """Result returned by an automation worker."""
 
@@ -47,6 +56,9 @@ class WorkResult:
     error: str = ""
     exit_code: int = 0
     pull_request_url: str | None = None
+    session_id: str | None = None
+    session_name: str | None = None
+    resume_command: str | None = None
 
 
 @dataclass(frozen=True)
@@ -58,3 +70,6 @@ class TickResult:
     task: AutomationTask | None = None
     pull_request_url: str | None = None
     detail: str = ""
+    session_id: str | None = None
+    session_name: str | None = None
+    resume_command: str | None = None

--- a/groundskeeper/protocols.py
+++ b/groundskeeper/protocols.py
@@ -7,6 +7,7 @@ from typing import Protocol
 from groundskeeper.domain.automation import (
     AutomationTask,
     ClaimResult,
+    SessionMetadata,
     TaskState,
     WorkResult,
 )
@@ -61,4 +62,5 @@ class Tracker(Protocol):
 class AutomationRunner(Protocol):
     """Executes a normalized automation task."""
 
+    def session_metadata(self, task: AutomationTask) -> SessionMetadata | None: ...
     def run(self, task: AutomationTask, recovery: bool = False) -> WorkResult: ...

--- a/tests/adapters/test_pi.py
+++ b/tests/adapters/test_pi.py
@@ -64,6 +64,26 @@ def test_pi_runner_renders_normalized_task_context_with_typed_settings() -> None
     assert client.settings.timeout_seconds == 7200
     assert "POLICY_OUTPUT: draft-pr" in client.prompt
     assert "POLICY_MERGE: never" in client.prompt
+    assert f"FACTORY_SESSION_ID: {client.settings.session_id}" in client.prompt
+    assert "FACTORY_SESSION_NAME: gk-me-dots-3" in client.prompt
+    assert (
+        f"FACTORY_RESUME_COMMAND: pi --session {client.settings.session_id}"
+        in client.prompt
+    )
+
+
+def test_pi_runner_exposes_session_metadata_without_starting_worker() -> None:
+    client = FakePiClient()
+    task = AutomationTask(
+        "github", "3", "Fix it", "Acceptance", "https://issue/3", "alex", "me/dots"
+    )
+
+    metadata = _runner(client).session_metadata(task)
+
+    assert metadata.session_id
+    assert metadata.session_name == "gk-me-dots-3"
+    assert metadata.resume_command == f"pi --session {metadata.session_id}"
+    assert client.settings is None
 
 
 def test_recovery_reuses_deterministic_session_and_changes_only_context() -> None:
@@ -84,11 +104,17 @@ class FakeProcess:
     def __init__(self) -> None:
         self.argv: tuple[str, ...] = ()
         self.timeout: int | None = None
+        self.streaming = False
 
-    def run(
-        self, argv: tuple[str, ...], cwd: Path, timeout: int | None = None
+    def run_streaming(
+        self,
+        argv: tuple[str, ...],
+        cwd: Path,
+        timeout: int | None = None,
+        stream: object | None = None,
     ) -> CommandResult:
         self.argv, self.timeout = argv, timeout
+        self.streaming = True
         return CommandResult(argv, cwd, 0, "https://github.com/me/repo/pull/8", "")
 
 
@@ -107,4 +133,8 @@ def test_pi_client_receives_only_rendered_prompt_and_typed_settings() -> None:
         "rendered task",
     )
     assert result.pull_request_url == "https://github.com/me/repo/pull/8"
+    assert result.session_id == "uuid"
+    assert result.session_name == "run-name"
+    assert result.resume_command == "pi --session uuid"
     assert process.timeout == 7200
+    assert process.streaming is True

--- a/tests/adapters/test_process.py
+++ b/tests/adapters/test_process.py
@@ -1,12 +1,111 @@
+import io
 import os
 import signal
 import sys
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from groundskeeper.adapters.process import ProcessClient
+from groundskeeper.adapters.process import PROCESS_ERROR_TAIL_CHARS, ProcessClient
+
+
+def test_streaming_process_fails_closed_without_process_groups(tmp_path: Path) -> None:
+    with patch(
+        "groundskeeper.adapters.process.STREAMING_PROCESS_GROUPS_SUPPORTED",
+        False,
+    ):
+        result = ProcessClient().run_streaming(
+            (sys.executable, "-c", "print('must not run')"),
+            tmp_path,
+            stream=io.StringIO(),
+        )
+
+    assert result.exit_code == 126
+    assert "requires POSIX" in result.stderr
+    assert result.stdout == ""
+
+
+def test_streaming_process_tees_combined_output_and_preserves_result(
+    tmp_path: Path,
+) -> None:
+    destination = io.StringIO()
+    script = (
+        "import sys; "
+        "print('stdout milestone', flush=True); "
+        "print('stderr milestone', file=sys.stderr, flush=True)"
+    )
+
+    result = ProcessClient().run_streaming(
+        (sys.executable, "-c", script), tmp_path, stream=destination
+    )
+
+    assert result.success
+    assert "stdout milestone" in result.stdout
+    assert "stderr milestone" in result.stdout
+    assert result.stderr == ""
+    assert destination.getvalue() == result.stdout
+
+
+def test_streaming_process_failure_keeps_output_as_error_detail(tmp_path: Path) -> None:
+    destination = io.StringIO()
+
+    result = ProcessClient().run_streaming(
+        (sys.executable, "-c", "print('failed detail'); raise SystemExit(3)"),
+        tmp_path,
+        stream=destination,
+    )
+
+    assert result.exit_code == 3
+    assert result.stderr == result.stdout
+    assert "failed detail" in result.stderr
+
+
+def test_streaming_process_failure_caps_error_detail(tmp_path: Path) -> None:
+    result = ProcessClient().run_streaming(
+        (
+            sys.executable,
+            "-c",
+            f"print('x' * {PROCESS_ERROR_TAIL_CHARS + 200}); raise SystemExit(3)",
+        ),
+        tmp_path,
+        stream=io.StringIO(),
+    )
+
+    assert len(result.stdout) > PROCESS_ERROR_TAIL_CHARS
+    assert len(result.stderr) == PROCESS_ERROR_TAIL_CHARS
+    assert result.stderr == result.stdout[-PROCESS_ERROR_TAIL_CHARS:]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="process groups require POSIX")
+def test_streaming_timeout_kills_descendant_holding_output_pipe(tmp_path: Path) -> None:
+    child_pid_path = tmp_path / "stream-child.pid"
+    child_script = "import signal, time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)"
+    parent_script = (
+        "import pathlib, subprocess, sys; "
+        f"child = subprocess.Popen([sys.executable, '-c', {child_script!r}]); "
+        f"pathlib.Path({str(child_pid_path)!r}).write_text(str(child.pid))"
+    )
+
+    result = ProcessClient().run_streaming(
+        (sys.executable, "-c", parent_script),
+        tmp_path,
+        timeout=1,
+        stream=io.StringIO(),
+    )
+
+    assert result.exit_code == 124
+    child_pid = int(child_pid_path.read_text())
+    for _ in range(20):
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.05)
+    else:
+        os.kill(child_pid, signal.SIGKILL)
+        pytest.fail("streaming timeout left descendant alive after parent exit")
 
 
 @pytest.mark.skipif(os.name != "posix", reason="process groups require POSIX")

--- a/tests/cli/test_cli_automation.py
+++ b/tests/cli/test_cli_automation.py
@@ -149,6 +149,29 @@ def test_tick_dry_run_omits_issue_body_from_json(
     assert json.loads(result.output)["data"]["task"]["id"] == "7"
 
 
+@patch("groundskeeper.cli.main.PiClient.supports_automation", return_value=False)
+@patch("groundskeeper.cli.main.PiClient.is_available", return_value=True)
+@patch("groundskeeper.cli.main.AutomationService.tick")
+def test_unsupported_host_fails_before_tracker_mutation(
+    mock_tick: object,
+    mock_available: object,
+    mock_supported: object,
+    tmp_path: Path,
+) -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path(".groundskeeper").mkdir(exist_ok=True)
+        Path(".groundskeeper/config.yml").write_text(CONFIG)
+        result = runner.invoke(cli, ["automation", "tick", "daily-dev", "--json"])
+
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert "requires POSIX process-group isolation" in payload["data"]["error"]
+    mock_available.assert_called_once()  # type: ignore[attr-defined]
+    mock_supported.assert_called_once()  # type: ignore[attr-defined]
+    mock_tick.assert_not_called()  # type: ignore[attr-defined]
+
+
 def test_text_errors_use_documented_exit_code(tmp_path: Path) -> None:
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):

--- a/tests/cli/test_cli_automation.py
+++ b/tests/cli/test_cli_automation.py
@@ -245,6 +245,32 @@ def test_blocked_result_has_stable_exit_code(
 
 
 @patch("groundskeeper.cli.main.PiClient.is_available", return_value=True)
+@patch("groundskeeper.cli.main.AutomationService.tick")
+def test_json_result_exposes_resumable_factory_session(
+    mock_tick: object, mock_available: object, tmp_path: Path
+) -> None:
+    mock_tick.return_value = TickResult(  # type: ignore[attr-defined]
+        "daily-dev",
+        "review",
+        pull_request_url="https://github/pr/9",
+        session_id="session-123",
+        session_name="gk-me-dots-7",
+        resume_command="pi --session session-123",
+    )
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path(".groundskeeper").mkdir(exist_ok=True)
+        Path(".groundskeeper/config.yml").write_text(CONFIG)
+        result = runner.invoke(cli, ["automation", "tick", "daily-dev", "--json"])
+
+    payload = json.loads(result.output)
+    assert result.exit_code == 0
+    assert payload["data"]["session_id"] == "session-123"
+    assert payload["data"]["session_name"] == "gk-me-dots-7"
+    assert payload["data"]["resume_command"] == "pi --session session-123"
+
+
+@patch("groundskeeper.cli.main.PiClient.is_available", return_value=True)
 @patch("groundskeeper.cli.main.TickLock.__enter__")
 def test_lock_contention_json_envelope(
     mock_enter: object, mock_available: object, tmp_path: Path

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -5,6 +5,7 @@ from groundskeeper.automation import AutomationService
 from groundskeeper.domain.automation import (
     AutomationTask,
     ClaimResult,
+    SessionMetadata,
     TaskState,
     WorkResult,
 )
@@ -53,9 +54,15 @@ def _raise_github_timeout(task: AutomationTask) -> str | None:
 
 
 class FakeRunner:
-    def __init__(self, result: WorkResult) -> None:
+    def __init__(
+        self, result: WorkResult, metadata: SessionMetadata | None = None
+    ) -> None:
         self.result = result
+        self.metadata = metadata
         self.calls = 0
+
+    def session_metadata(self, task: AutomationTask) -> SessionMetadata | None:
+        return self.metadata
 
     def run(self, task: AutomationTask, recovery: bool = False) -> WorkResult:
         self.calls += 1
@@ -78,6 +85,32 @@ def test_success_requires_pr_and_transitions_to_review() -> None:
     result = AutomationService(tracker, runner).tick(AUTOMATION)
     assert result.status == "review"
     assert tracker.transitions == [(TaskState.REVIEW, "https://github/pr/1")]
+
+
+def test_successful_review_propagates_resumable_session_metadata() -> None:
+    tracker = FakeTracker()
+    pull_requests = iter([None, "https://github/pr/1"])
+    tracker.find_pull_request = lambda task: next(pull_requests)  # type: ignore[method-assign]
+    worker = WorkResult(
+        True,
+        session_id="session-123",
+        session_name="gk-me-dots-7",
+        resume_command="pi --session session-123",
+    )
+
+    result = AutomationService(tracker, FakeRunner(worker)).tick(AUTOMATION)
+
+    assert result.status == "review"
+    assert result.session_id == "session-123"
+    assert result.session_name == "gk-me-dots-7"
+    assert result.resume_command == "pi --session session-123"
+    assert result.detail == (
+        "https://github/pr/1\n\n"
+        "Factory session: `session-123`\n"
+        "Session name: `gk-me-dots-7`\n"
+        "Resume: `pi --session session-123`"
+    )
+    assert tracker.transitions == [(TaskState.REVIEW, result.detail)]
 
 
 def test_worker_failure_with_valid_draft_pr_reconciles_to_review() -> None:
@@ -140,6 +173,25 @@ def test_timed_out_worker_is_blocked_with_actionable_detail() -> None:
     ]
 
 
+def test_worker_failure_includes_resumable_session_metadata() -> None:
+    tracker = FakeTracker()
+    worker = WorkResult(
+        False,
+        error="boom",
+        exit_code=1,
+        session_id="session-123",
+        session_name="gk-me-dots-7",
+        resume_command="pi --session session-123",
+    )
+
+    result = AutomationService(tracker, FakeRunner(worker)).tick(AUTOMATION)
+
+    assert result.status == "blocked"
+    assert result.session_id == "session-123"
+    assert result.detail.startswith("boom\n\nFactory session: `session-123`")
+    assert tracker.transitions == [(TaskState.BLOCKED, result.detail)]
+
+
 def test_worker_failure_is_visible_and_recoverable() -> None:
     tracker = FakeTracker()
     result = AutomationService(
@@ -155,6 +207,25 @@ def test_existing_pr_reconciles_without_dispatch() -> None:
     runner = FakeRunner(WorkResult(True))
     result = AutomationService(tracker, runner).tick(AUTOMATION)
     assert result.status == "review"
+    assert runner.calls == 0
+
+
+def test_running_task_with_existing_pr_preserves_session_handoff() -> None:
+    tracker = FakeTracker()
+    running = replace(TASK, state=TaskState.RUNNING)
+    tracker.list_running = lambda: [running]  # type: ignore[method-assign]
+    tracker.pr = "https://github/pr/9"
+    metadata = SessionMetadata(
+        "session-123", "gk-me-dots-7", "pi --session session-123"
+    )
+    runner = FakeRunner(WorkResult(True), metadata)
+
+    result = AutomationService(tracker, runner).tick(AUTOMATION)
+
+    assert result.status == "review"
+    assert result.session_id == "session-123"
+    assert result.detail.startswith("https://github/pr/9\n\nFactory session")
+    assert tracker.transitions == [(TaskState.REVIEW, result.detail)]
     assert runner.calls == 0
 
 


### PR DESCRIPTION
## Summary

- stream combined Pi child output to stderr while retaining bounded buffered output for PR parsing and failure details
- enforce POSIX process-group isolation before issue claim and include pipe-draining descendants in the timeout boundary
- expose deterministic session ID, stable name, and resume command in automation context, JSON results, and GitHub review/blocked comments
- preserve session handoff metadata when recovering a running issue that already created its draft PR
- document live logging, resume metadata, and platform safety boundaries

## Test plan

- [x] `mise run check` — 215 passed, 32 deselected; Ruff, format, and ty pass
- [x] `mise run docs:build`
- [x] context-engineering docs verification
- [x] streaming success/failure, error-tail, descendant-pipe timeout, and non-POSIX fail-closed regressions
- [x] session metadata propagation through normal, blocked, recovery, CLI JSON, and prompt context paths
- [x] two fresh-context review rounds; no remaining P0-P2 findings

🤖 AI-authored change and PR description.

