### PR TITLE
Publish bounded factory blocker details

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,12 @@ Each issue maps to a deterministic UUIDv5 Pi session and stable run name. Pi
 output streams to Groundskeeper's stderr for live scheduler logs while the final
 versioned JSON result remains on stdout. Review, deferred, and blocked results
 include the session ID, name, and generic `pi --session ID` resume command;
-GitHub transition comments preserve the same handoff metadata. Streaming Pi
+GitHub transition comments preserve the same handoff metadata. When no PR is
+created, an automation skill may expose a bounded public-safe explanation with
+one final `FACTORY_RESULT_JSON={"status":"blocked","summary":"...","next_action":"..."}`
+line. Groundskeeper validates that exact shape, caps it at 8,000 characters,
+neutralizes GitHub mentions, and publishes only the summary and next action.
+Arbitrary Pi stdout is never copied into an issue comment. Streaming Pi
 automations require a
 POSIX host so Groundskeeper can terminate the complete process group before
 releasing repository locks; unsupported hosts fail before starting Pi.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,13 +87,16 @@ automation config
   → render configured skill + task/recovery/policy/session context
   → require POSIX process-group isolation
   → run Pi in a deterministic session with a bounded process group
-      combined child output → Groundskeeper stderr for live logs
-      buffered output → PR URL parsing and failure detail
+      stdout + stderr → separately preserved and tee'd to live scheduler logs
+      stdout → PR URL parsing + strict public blocker marker extraction
+      stderr → transient/durable provider failure classification
   → reconcile GitHub as the durable result authority
       exact closing open draft PR → review
       non-draft, closed, or merged closing PR → blocked policy violation
       no accepted PR + explicit transient provider exhaustion → deferred
       no accepted PR + durable/ordinary worker failure → blocked worker error
+      valid public blocker marker → bounded summary + next action in issue comment
+      arbitrary worker stdout → local logs only
   → expose session id, stable name, and resume command in JSON + issue comment
 ```
 

--- a/docs/config-and-skills.md
+++ b/docs/config-and-skills.md
@@ -55,8 +55,12 @@ open-draft closing PR. Explicit Codex usage-limit, rate-limit/HTTP 429, and
 temporary provider-capacity failures then move running work to deferred for a
 deterministic-session resume on the next tick. Authentication, missing or
 misconfigured models, policy failures, ordinary worker failures, and Pi timeouts
-remain blocked. The host lock is released when
-the tick exits. Automation entries are strict:
+remain blocked. For a no-PR outcome, the skill may end with one strict
+`FACTORY_RESULT_JSON` line containing `status: blocked`, a public-safe summary,
+and a next action. Valid bounded content becomes the blocked issue explanation;
+malformed, oversized, or absent markers use the generic fallback, and arbitrary
+worker stdout remains local. The host lock is released when the tick exits.
+Automation entries are strict:
 unknown keys are rejected at the entry, source, runner, policy, and labels
 levels. For example, use `timeout-seconds`, not `timeout_seconds`, and
 `concurrency`, not `concurency`. A misspelled top-level `automation:` key is

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -39,7 +39,10 @@ selects and reports eligible work without labels, comments, or worker launch.
 Its compact output omits issue bodies. Pi child output is streamed to stderr so
 scheduler logs show progress without corrupting JSON stdout. Review, deferred,
 and blocked results expose `session_id`, `session_name`, and `resume_command` in
-the JSON `data` object. A deferred result means Pi reported an explicit transient
+the JSON `data` object. A blocked result may also contain a strict, bounded
+public summary/next-action marker emitted by the automation skill; unmarked Pi
+stdout remains local and the generic blocker text is the safe fallback. A
+deferred result means Pi reported an explicit transient
 provider exhaustion signal and the deterministic session will be reclaimed on a
 later tick. The generic resume command uses `pi`; callers with auth
 profiles can substitute their profile wrapper, such as `pih`. Pi automation

--- a/groundskeeper/adapters/pi.py
+++ b/groundskeeper/adapters/pi.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import sys
@@ -43,6 +44,9 @@ _BLOCKING_PROVIDER_PATTERNS = (
     ),
 )
 
+FACTORY_RESULT_PREFIX = "FACTORY_RESULT_JSON="
+FACTORY_PUBLIC_DETAIL_MAX_CHARS = 8_000
+
 _TRANSIENT_PROVIDER_PATTERNS = (
     re.compile(
         r"\b(?:codex\s+)?usage limit (?:has been )?reached\b"
@@ -66,6 +70,66 @@ _TRANSIENT_PROVIDER_PATTERNS = (
         re.IGNORECASE | re.DOTALL,
     ),
 )
+
+
+def _json_object_without_duplicate_keys(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _unsafe_public_character(character: str) -> bool:
+    codepoint = ord(character)
+    return codepoint < 32 or 127 <= codepoint <= 159
+
+
+def _public_detail(output: str) -> str | None:
+    """Extract exactly one final bounded public-safe blocker marker."""
+    lines = output.rstrip().splitlines()
+    marker_indexes = [
+        index
+        for index, line in enumerate(lines)
+        if line.startswith(FACTORY_RESULT_PREFIX)
+    ]
+    if marker_indexes != [len(lines) - 1]:
+        return None
+    payload_text = lines[-1].removeprefix(FACTORY_RESULT_PREFIX)
+    if len(payload_text) > FACTORY_PUBLIC_DETAIL_MAX_CHARS:
+        return None
+    try:
+        payload = json.loads(
+            payload_text,
+            object_pairs_hook=_json_object_without_duplicate_keys,
+        )
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(payload, dict) or set(payload) != {
+        "status",
+        "summary",
+        "next_action",
+    }:
+        return None
+    if payload.get("status") != "blocked":
+        return None
+    summary = payload.get("summary")
+    next_action = payload.get("next_action")
+    if not isinstance(summary, str) or not isinstance(next_action, str):
+        return None
+    if any(_unsafe_public_character(character) for character in summary + next_action):
+        return None
+    summary = summary.strip()
+    next_action = next_action.strip()
+    if not summary or not next_action:
+        return None
+    rendered = f"Summary: {summary}\n\nNext action: {next_action}"
+    # Prevent model-authored public summaries from pinging GitHub users or teams.
+    rendered = rendered.replace("@", "@\u200b")
+    return rendered if len(rendered) <= FACTORY_PUBLIC_DETAIL_MAX_CHARS else None
 
 
 def _failure_disposition(error: str, exit_code: int) -> FailureDisposition:
@@ -122,12 +186,10 @@ class PiClient:
             flush=True,
         )
         match = re.search(r"https://github\.com/[^\s]+/pull/\d+", result.stdout)
+        # Stdout may contain private worker reasoning. Only explicit public markers
+        # are publishable; unmarked failures use stderr or the generic exit fallback.
         error_detail = (
-            result.stderr[-PROCESS_ERROR_TAIL_CHARS:]
-            if result.stderr
-            else result.stdout[-PROCESS_ERROR_TAIL_CHARS:]
-            if not result.success
-            else ""
+            result.stderr[-PROCESS_ERROR_TAIL_CHARS:] if result.stderr else ""
         )
         return WorkResult(
             success=result.success,
@@ -138,6 +200,7 @@ class PiClient:
             session_id=settings.session_id,
             session_name=settings.name,
             resume_command=f"pi --session {settings.session_id}",
+            public_detail=_public_detail(result.stdout),
             failure_disposition=(
                 FailureDisposition.BLOCKED
                 if result.success

--- a/groundskeeper/automation.py
+++ b/groundskeeper/automation.py
@@ -121,11 +121,12 @@ class AutomationService:
             detail = result.error.strip() or f"worker exited {result.exit_code}"
             if result.failure_disposition is FailureDisposition.DEFERRED:
                 return self._defer(name, task, detail, result)
-            return self._block(name, task, detail, result)
+            return self._block(name, task, result.public_detail or detail, result)
         return self._block(
             name,
             task,
-            "Worker completed without an open draft pull request",
+            result.public_detail
+            or "Worker completed without an open draft pull request",
             result,
         )
 

--- a/groundskeeper/domain/automation.py
+++ b/groundskeeper/domain/automation.py
@@ -67,6 +67,7 @@ class WorkResult:
     session_id: str | None = None
     session_name: str | None = None
     resume_command: str | None = None
+    public_detail: str | None = None
     failure_disposition: FailureDisposition = FailureDisposition.BLOCKED
 
 

--- a/tests/adapters/test_pi.py
+++ b/tests/adapters/test_pi.py
@@ -1,4 +1,5 @@
 import io
+import json
 import sys
 from pathlib import Path
 
@@ -9,9 +10,11 @@ from groundskeeper.adapters.automation_runner import (
     PiAutomationRunner,
 )
 from groundskeeper.adapters.pi import (
+    FACTORY_PUBLIC_DETAIL_MAX_CHARS,
     PiClient,
     PiExecutionSettings,
     _failure_disposition,
+    _public_detail,
 )
 from groundskeeper.adapters.process import (
     PROCESS_ERROR_TAIL_CHARS,
@@ -159,6 +162,72 @@ def test_pi_client_receives_only_rendered_prompt_and_typed_settings() -> None:
     assert process.streaming is True
 
 
+def test_public_detail_uses_exactly_one_final_bounded_blocker_marker() -> None:
+    final = json.dumps(
+        {
+            "status": "blocked",
+            "summary": "Focused tests pass; @reviewer input is required.",
+            "next_action": "Approve the recorded validation skip, then resume.",
+        }
+    )
+
+    detail = _public_detail(
+        f"arbitrary private worker output\nFACTORY_RESULT_JSON={final}\n"
+    )
+
+    assert detail == (
+        "Summary: Focused tests pass; @\u200breviewer input is required.\n\n"
+        "Next action: Approve the recorded validation skip, then resume."
+    )
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "arbitrary worker output",
+        "FACTORY_RESULT_JSON=not-json",
+        'FACTORY_RESULT_JSON={"status":"review","summary":"x","next_action":"y"}',
+        'FACTORY_RESULT_JSON={"status":"blocked","summary":"x"}',
+        'FACTORY_RESULT_JSON={"status":"blocked","summary":"","next_action":"y"}',
+        "FACTORY_RESULT_JSON=" + ("x" * (FACTORY_PUBLIC_DETAIL_MAX_CHARS + 1)),
+        "FACTORY_RESULT_JSON="
+        + json.dumps(
+            {"status": "blocked", "summary": "unsafe\nline", "next_action": "retry"}
+        ),
+        "FACTORY_RESULT_JSON="
+        + json.dumps(
+            {"status": "blocked", "summary": "unsafe\ttab", "next_action": "retry"}
+        ),
+        "FACTORY_RESULT_JSON="
+        + json.dumps(
+            {"status": "blocked", "summary": "unsafe\u001b", "next_action": "retry"}
+        ),
+        "FACTORY_RESULT_JSON="
+        + json.dumps(
+            {"status": "blocked", "summary": "unsafe\u007f", "next_action": "retry"}
+        ),
+        "FACTORY_RESULT_JSON="
+        + json.dumps(
+            {"status": "blocked", "summary": "unsafe\u0085", "next_action": "retry"}
+        ),
+        'FACTORY_RESULT_JSON={"status":"blocked","status":"blocked",'
+        '"summary":"x","next_action":"y"}',
+        'FACTORY_RESULT_JSON={"status":"blocked","summary":"old","next_action":"x"}\n'
+        'FACTORY_RESULT_JSON={"status":"blocked","summary":"new","next_action":"y"}',
+        'FACTORY_RESULT_JSON={"status":"blocked","summary":"x","next_action":"y"}\n'
+        "later private output",
+        'FACTORY_RESULT_JSON={"status":"blocked","summary":"x","next_action":"y"}\n'
+        "FACTORY_RESULT_JSON=malformed",
+        "FACTORY_RESULT_JSON="
+        + json.dumps(
+            {"status": "blocked", "summary": "@" * 3_990, "next_action": "retry"}
+        ),
+    ],
+)
+def test_public_detail_rejects_untrusted_or_invalid_worker_output(output: str) -> None:
+    assert _public_detail(output) is None
+
+
 @pytest.mark.parametrize(
     "error",
     [
@@ -252,6 +321,20 @@ def test_pi_client_ignores_transient_text_in_worker_output() -> None:
     )
 
     assert result.failure_disposition is FailureDisposition.BLOCKED
+
+
+def test_pi_client_never_uses_unmarked_stdout_as_public_failure_detail() -> None:
+    process = FakeProcess(
+        CommandResult((), Path("/repo"), 1, "private worker failure analysis", "")
+    )
+
+    result = PiClient(process).run_prompt(  # type: ignore[arg-type]
+        "rendered task", Path("/repo"), PiExecutionSettings("uuid", "run-name")
+    )
+
+    assert result.error == ""
+    assert result.public_detail is None
+    assert result.output == "private worker failure analysis"
 
 
 def test_pi_client_prioritizes_durable_diagnostic_over_transient_text() -> None:

--- a/tests/e2e/test_e2e_commands.py
+++ b/tests/e2e/test_e2e_commands.py
@@ -85,6 +85,46 @@ def _factory_flow_repo(
     return repo, env
 
 
+def _public_blocker_factory_repo(
+    tmp_path: Path,
+) -> tuple[Path, dict[str, str], Path]:
+    repo, env = _factory_repo(tmp_path, "[]")
+    binary_dir = tmp_path / "bin"
+    gh_log = tmp_path / "public-blocker-gh.log"
+    issue = (
+        '[{"number":7,"title":"Do work","body":"Acceptance",'
+        '"url":"https://github.com/me/repo/issues/7",'
+        '"author":{"login":"alex"},"labels":[{"name":"factory:ready"}]}]'
+    )
+    (binary_dir / "gh").write_text(
+        "#!/bin/sh\n"
+        f"LOG='{gh_log}'\n"
+        'case "$*" in\n'
+        f"  *\"issue list\"*\"factory:ready\"*) printf '%s' '{issue}' ;;\n"
+        "  *\"issue list\"*) printf '%s' '[]' ;;\n"
+        "  *\"pr list\"*) printf '%s' '[]' ;;\n"
+        '  *"issue comment"*) printf \'%s\' "$*" >> "$LOG" ;;\n'
+        "  *) printf '%s' '' ;;\n"
+        "esac\n"
+    )
+    marker = json.dumps(
+        {
+            "status": "blocked",
+            "summary": "Focused tests pass; review requires a decision.",
+            "next_action": "Approve the recorded skip, then resume.",
+        },
+        separators=(",", ":"),
+    )
+    pi = binary_dir / "pi"
+    pi.write_text(
+        "#!/bin/sh\n"
+        "printf '%s\\n' 'private worker analysis must not be published'\n"
+        f"printf '%s\\n' 'FACTORY_RESULT_JSON={marker}'\n"
+    )
+    pi.chmod(0o755)
+    return repo, env, gh_log
+
+
 def _deferred_factory_repo(tmp_path: Path) -> tuple[Path, dict[str, str], Path, Path]:
     repo, env = _factory_repo(tmp_path, "[]")
     binary_dir = tmp_path / "bin"
@@ -246,6 +286,23 @@ class TestAutomationE2E:
         result = run_gk("automation", "tick", "daily", "--json", cwd=repo, env=env)
         assert result.returncode == 5
         assert json.loads(result.stdout)["status"] == "blocked"
+
+    def test_public_blocker_marker_reaches_comment_without_private_output(
+        self, tmp_path: Path
+    ) -> None:
+        repo, env, gh_log = _public_blocker_factory_repo(tmp_path)
+
+        result = run_gk("automation", "tick", "daily", "--json", cwd=repo, env=env)
+
+        assert result.returncode == 5
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "blocked"
+        assert "Focused tests pass" in payload["data"]["detail"]
+        comment = gh_log.read_text()
+        assert "Focused tests pass" in comment
+        assert "Approve the recorded skip" in comment
+        assert "private worker analysis" not in comment
+        assert "FACTORY_RESULT_JSON" not in comment
 
     def test_running_issue_resumes_to_review(self, tmp_path: Path) -> None:
         repo, env = _factory_flow_repo(tmp_path, "running")

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -105,6 +105,7 @@ def test_successful_review_propagates_resumable_session_metadata() -> None:
         session_id="session-123",
         session_name="gk-me-dots-7",
         resume_command="pi --session session-123",
+        public_detail="Summary: should not replace PR authority",
     )
 
     result = AutomationService(tracker, FakeRunner(worker)).tick(AUTOMATION)
@@ -132,6 +133,45 @@ def test_worker_failure_with_valid_draft_pr_reconciles_to_review() -> None:
     assert tracker.transitions == [(TaskState.REVIEW, "https://github/pr/1")]
 
 
+def test_public_blocker_detail_is_used_when_no_draft_pr_exists() -> None:
+    tracker = FakeTracker()
+    worker = WorkResult(
+        True,
+        public_detail=(
+            "Summary: Focused tests pass, but review requires a decision.\n\n"
+            "Next action: Approve the recorded skip and resume."
+        ),
+        session_id="session-123",
+        resume_command="pi --session session-123",
+    )
+
+    result = AutomationService(tracker, FakeRunner(worker)).tick(AUTOMATION)
+
+    assert result.status == "blocked"
+    assert result.detail == (
+        "Summary: Focused tests pass, but review requires a decision.\n\n"
+        "Next action: Approve the recorded skip and resume.\n\n"
+        "Factory session: `session-123`\n"
+        "Resume: `pi --session session-123`"
+    )
+    assert tracker.transitions == [(TaskState.BLOCKED, result.detail)]
+
+
+def test_public_blocker_detail_is_used_for_durable_worker_failure() -> None:
+    tracker = FakeTracker()
+    worker = WorkResult(
+        False,
+        error="private process detail",
+        exit_code=1,
+        public_detail="Summary: Public-safe failure.\n\nNext action: Fix it.",
+    )
+
+    result = AutomationService(tracker, FakeRunner(worker)).tick(AUTOMATION)
+
+    assert result.status == "blocked"
+    assert result.detail == "Summary: Public-safe failure.\n\nNext action: Fix it."
+
+
 def test_worker_output_pr_must_match_tracker_closing_reference() -> None:
     tracker = FakeTracker()
     result = AutomationService(
@@ -149,7 +189,10 @@ def test_worker_output_pr_must_match_tracker_closing_reference() -> None:
 def test_noncompliant_closing_pr_is_blocked_as_policy_violation() -> None:
     tracker = FakeTracker()
     tracker.policy_violation = "Closing pull request is not a draft"
-    result = AutomationService(tracker, FakeRunner(WorkResult(True))).tick(AUTOMATION)
+    result = AutomationService(
+        tracker,
+        FakeRunner(WorkResult(True, public_detail="Summary: must not override policy")),
+    ).tick(AUTOMATION)
     assert result.status == "blocked"
     assert tracker.transitions == [
         (TaskState.BLOCKED, "Closing pull request is not a draft")


### PR DESCRIPTION
## Summary
- parse one strict final `FACTORY_RESULT_JSON` blocker marker from Pi output
- publish only bounded public-safe summary and next action content
- keep arbitrary stdout local and use stderr/generic fallback for unmarked failures
- reject malformed, duplicate-key, multiple, nonfinal, oversized, mention-triggering, and control-bearing markers
- preserve accepted PR, policy violation, transient deferral, and session metadata authority

## Validation
- full suite: 267 passed, 34 E2E deselected
- installed-CLI E2E: 34 passed
- Ruff, format, ty, strict docs build passed
- fresh public-safety review findings fixed
- HK ready and handoff complete
