### PR TITLE
Support cross-repository automation targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ automations:
   daily-maintenance:
     source:
       type: github-issues
-      repository: example/widgets
-      repository-path: /Users/you/src/widgets
+      repository: example/work-factory
       trusted-authors: [maintainer]
       labels:
         ready: factory:ready
@@ -27,6 +26,9 @@ automations:
         deferred: factory:deferred
         review: factory:review
         blocked: factory:blocked
+    target:
+      repository: example/widgets
+      repository-path: /Users/you/src/widgets
     runner:
       type: pi
       skill: issue-implementation
@@ -41,8 +43,11 @@ automations:
 
 Create `issue-implementation` as an ordinary skill under
 `.groundskeeper/skills/`. It receives its usual prompt plus `TASK_ID`,
-`TASK_TITLE`, `TASK_BODY`, `TASK_URL`, `REPOSITORY`, `RECOVERY_CONTEXT`, and
-the fixed `POLICY_CONCURRENCY`, `POLICY_OUTPUT`, and `POLICY_MERGE` fields.
+`TASK_TITLE`, `TASK_BODY`, `TASK_URL`, `REPOSITORY`,
+`FACTORY_CLOSING_REFERENCE`, `RECOVERY_CONTEXT`, and the fixed
+`POLICY_CONCURRENCY`, `POLICY_OUTPUT`, and `POLICY_MERGE` fields. `REPOSITORY`
+is the target repository. The closing reference is `#123` for a same-repository
+queue or `example/work-factory#123` for a cross-repository queue.
 Normal `gk run` and `gk render` behavior for that skill is unchanged.
 
 ```bash
@@ -52,23 +57,31 @@ gk automation tick daily-maintenance --dry-run --json
 gk automation tick daily-maintenance --json
 ```
 
-`validate` checks configuration, skill resolution, the Pi executable, repository
-path, and fixed policy without contacting GitHub or claiming work. `tick` is
-noninteractive and uses a host-local advisory lock keyed by normalized GitHub
-repository identity. Locks live under `$XDG_STATE_HOME/groundskeeper/locks`
+`validate` checks configuration, skill resolution, the Pi executable, fixed
+policy, and that the target path is a Git worktree whose GitHub `origin` matches
+the configured target, without contacting GitHub or claiming work. Dry-run and
+live tick perform that checkout preflight before tracker access. Source issue
+discovery, admission, labels, dependencies, and comments stay in the source
+repository. Pi runs in the target path. Pull-request reconciliation queries the
+exact source issue's closing-PR connection and filters results to the target
+repository. `tick` is noninteractive and uses a host-local
+advisory lock keyed by canonical source repository identity. Locks live under `$XDG_STATE_HOME/groundskeeper/locks`
 (or `~/.local/state/groundskeeper/locks`), so separate config worktrees for the
 same repository share one host lock. `GROUNDSKEEPER_STATE_HOME` is a narrow
 host/test override. Run exactly one scheduler host for each automation;
 multi-host scheduling is not supported. A tick reconciles running work first,
 then atomically reclaims deferred work, then claims new ready work. A successful
-no-work tick is safe. After any worker return, Groundskeeper first reconciles the
-accepted GitHub result: an open draft PR with the exact closing reference moves
-to review even if the worker reported a late failure. Explicit Codex usage,
+no-work tick is safe. Before dispatch and after any worker return, Groundskeeper
+reconciles the accepted GitHub result: an open draft PR in the target repository
+with the exact repository-qualified source issue closing reference moves to
+review even if the worker reported a late failure. If accepted and violating
+exact target PRs coexist, the accepted draft wins; otherwise a non-draft, closed,
+or merged exact target PR blocks without dispatch. Explicit Codex usage,
 provider rate-limit/HTTP 429, and temporary provider-capacity failures move the
 issue to `factory:deferred` with an actionable comment and are resumed on the
 next tick. Authentication, model configuration, policy, timeout, and ordinary
-worker failures move it to `factory:blocked`. The JSON contract is versioned,
-and dry-run output deliberately omits
+worker failures move it to `factory:blocked`. The breaking source/target JSON
+shape uses envelope version `2`, and dry-run output deliberately omits
 issue bodies. Set a scheduler's working directory to the repository containing
 `.groundskeeper/config.yml`, or pass `gk automation --config PATH ...`.
 
@@ -83,7 +96,8 @@ factory:ready ──claim──> factory:running ──accepted draft PR──> 
 factory:deferred ──next tick claim/resume──> factory:running
 ```
 
-Each issue maps to a deterministic UUIDv5 Pi session and stable run name. Pi
+Each source repository, issue number, and target repository tuple maps to a
+deterministic UUIDv5 Pi session and stable run name. Pi
 output streams to Groundskeeper's stderr for live scheduler logs while the final
 versioned JSON result remains on stdout. Review, deferred, and blocked results
 include the session ID, name, and generic `pi --session ID` resume command;
@@ -104,6 +118,8 @@ blocks the claimed issue with the command error and releases the host lock for r
 If a process exits after claiming an issue, the next tick resumes that session
 and reconciles GitHub state. Issue discovery requests ready, running, and
 deferred labels server-side and is bounded at 1,000 open issues per state.
+Pull request reconciliation inspects the exact source issue's repository-qualified
+closing pull request references and filters them to the configured target repository.
 
 Define AI agent skills as markdown prompt templates. Chain them into workflows. Run them locally or generate GitHub Actions workflows that run them on PRs or schedules.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,22 +79,26 @@ For workflows: steps execute sequentially. `ParallelGroup` steps use `ThreadPool
 
 ```text
 automation config
-  → strict source, runner, labels, timeout, and policy parsing
+  → strict source queue, target repository/path, runner, labels, timeout, and policy parsing
   → resolve configured skill with provenance
-  → acquire stable host-state lock for normalized repository identity
+  → prove target path is a Git worktree whose origin matches target repository
+  → acquire stable host-state lock for canonical source repository identity
   → reconcile running issues before deferred work before ready work
   → parse one exact Factory Task + Dependencies contract and resolve dependency state
   → block malformed, tracking, inaccessible, unresolved, or closed-unmerged dependency work before Pi
   → atomically claim at most one admitted trusted deferred or ready task
-  → render configured skill + typed task-contract/recovery/policy/session context
+  → normalize the repository-qualified source issue and explicit target identity
+  → render configured skill + typed closing/task-contract/recovery/policy/session context
   → require POSIX process-group isolation
-  → run Pi in a deterministic session with a bounded process group
+  → run Pi in the target checkout with a deterministic session keyed by source + issue + target
       stdout + stderr → separately preserved and tee'd to live scheduler logs
       stdout → PR URL parsing + strict public blocker marker extraction
       stderr → transient/durable provider failure classification
   → reconcile GitHub as the durable result authority
-      exact closing open draft PR → review
-      non-draft, closed, or merged closing PR → blocked policy violation
+      exact source issue's closedByPullRequestsReferences filtered to target repository
+      accepted open target draft PR → review (wins if a violating PR also exists)
+      otherwise non-draft, closed, or merged target closing PR → blocked policy violation
+      explicit closing-PR page exhaustion → indeterminate error without lifecycle mutation
       no accepted PR + explicit transient provider exhaustion → deferred
       no accepted PR + durable/ordinary worker failure → blocked worker error
       valid public blocker marker → bounded summary + next action in issue comment
@@ -115,8 +119,10 @@ Deferred claims return the issue to `running` before Pi resumes the same UUIDv5
 session. A repeat transient failure returns it to `deferred`; a later accepted
 draft PR reaches `review`.
 
-The workflow instructions belong to the configured skill; the Pi adapter knows
-only how to execute a rendered prompt. `merge: never` is an accepted-result
+The source repository owns discovery, admission, dependencies, labels, comments,
+and lifecycle. The target repository/path owns Pi cwd, rendered `REPOSITORY`,
+and accepted draft PR discovery. The workflow instructions belong to the
+configured skill; the Pi adapter knows only how to execute a rendered prompt. `merge: never` is an accepted-result
 contract, not a credential sandbox. Host-state locking coordinates config
 worktrees on one machine and does not provide distributed locking.
 

--- a/docs/config-and-skills.md
+++ b/docs/config-and-skills.md
@@ -21,15 +21,20 @@ and dispatch it through one named Groundskeeper skill.
 
 The initial provider pair is `source.type: github-issues` and `runner.type: pi`.
 A Pi runner must explicitly name `skill`, use `approval: allow`, and use
-`session: deterministic`. Each source requires `repository`, `repository-path`,
-and at least one `trusted-author`. Safety policy is strict: concurrency is `1`,
-output is `draft-pr`, and merge is `never`. Groundskeeper validates this policy
-and enforces the accepted-result postcondition: only an open draft pull request
-with the exact closing reference reaches review. It does not sandbox a
-user-authorized Pi process. An automation skill receives normalized `TASK_ID`,
-`TASK_TITLE`, `TASK_BODY`, `TASK_URL`, `REPOSITORY`, `RECOVERY_CONTEXT`, and
-`POLICY_CONCURRENCY`, `POLICY_OUTPUT`, and `POLICY_MERGE`; ordinary skill
-rendering is unchanged.
+`session: deterministic`. Every automation requires an explicit `source` and
+`target`. Source and target repositories must be canonical `owner/repo`
+identities. The source requires `repository` and at least one `trusted-author`;
+the target requires `repository` and an absolute `repository-path`. Validation,
+dry-run, and live tick prove that path is a Git worktree whose `origin` GitHub
+HTTPS or SSH remote matches the configured target before tracker access. Safety
+policy is strict: concurrency is `1`, output is `draft-pr`, and merge is `never`.
+Groundskeeper validates this policy and enforces the accepted-result
+postcondition: only an open draft pull request in the target repository that
+closes the exact repository-qualified source issue reaches review. It does not
+sandbox a user-authorized Pi process. An automation skill receives normalized
+`TASK_ID`, `TASK_TITLE`, `TASK_BODY`, `TASK_URL`, target `REPOSITORY`, typed
+`FACTORY_CLOSING_REFERENCE`, `RECOVERY_CONTEXT`, and `POLICY_CONCURRENCY`,
+`POLICY_OUTPUT`, and `POLICY_MERGE`; ordinary skill rendering is unchanged.
 
 Every GitHub Issues automation task must begin with exactly these first two H2
 sections. The contract sections cannot contain comments or fenced examples:
@@ -63,8 +68,7 @@ below; every override must be a non-empty string and all five must be distinct:
 ```yaml
 source:
   type: github-issues
-  repository: example/widgets
-  repository-path: /srv/widgets
+  repository: example/work-factory
   trusted-authors: [maintainer]
   labels:
     ready: factory:ready
@@ -72,12 +76,18 @@ source:
     deferred: factory:deferred
     review: factory:review
     blocked: factory:blocked
+target:
+  repository: example/widgets
+  repository-path: /srv/widgets
 ```
 
 Pi runners accept optional positive `timeout-seconds` (default: `7200`) for
 long-running development work. GitHub CLI operations use a fixed 30-second
-timeout. After any worker return, Groundskeeper first reconciles the accepted
-open-draft closing PR. Explicit Codex usage-limit, rate-limit/HTTP 429, and
+timeout. Before dispatch and after any worker return, Groundskeeper reconciles the exact
+source issue's closing-PR connection, filtered to the target repository. An
+accepted open draft wins if accepted and violating PRs coexist; otherwise an
+exact non-draft, closed, or merged target PR blocks without dispatch. Explicit
+Codex usage-limit, rate-limit/HTTP 429, and
 temporary provider-capacity failures then move running work to deferred for a
 deterministic-session resume on the next tick. Authentication, missing or
 misconfigured models, policy failures, ordinary worker failures, and Pi timeouts
@@ -87,9 +97,10 @@ and a next action. Valid bounded content becomes the blocked issue explanation;
 malformed, oversized, or absent markers use the generic fallback, and arbitrary
 worker stdout remains local. The host lock is released when the tick exits.
 Automation entries are strict:
-unknown keys are rejected at the entry, source, runner, policy, and labels
-levels. For example, use `timeout-seconds`, not `timeout_seconds`, and
-`concurrency`, not `concurency`. A misspelled top-level `automation:` key is
+unknown keys are rejected at the entry, source, target, runner, policy, and
+labels levels. The removed source-level `repository-path` is rejected as an unknown
+key. For example, use target `repository-path`, `timeout-seconds`, not
+`timeout_seconds`, and `concurrency`, not `concurency`. A misspelled top-level `automation:` key is
 rejected; legacy top-level workflow configuration remains valid. See the README
 for a complete configuration.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -32,12 +32,16 @@ gk automation tick NAME [--dry-run] [--json]
 `list` and `show` inspect configured local automations. `inspect` reads tracker
 items and reports Factory Task parsing, dependency resolution, and deterministic
 admission without labels, comments, or worker launch. `show --json` includes
-the resolved repository path, lifecycle labels, runner settings, policy, and
-selected-skill provenance (name, source kind, and path, never the prompt body).
+distinct source queue and target repository/path objects, lifecycle labels,
+runner settings, policy, and selected-skill provenance (name, source kind, and
+path, never the prompt body). `inspect --json` and `tick --json` also expose
+source and target separately while dry-run continues to omit issue bodies.
 `validate --json` returns the same resolved skill provenance after checking it.
 `validate` checks strict config, named-skill resolution, Pi availability, the
-repository path, and the fixed draft-only/never-merge policy without contacting
-GitHub or starting work. `tick` runs one bounded reconciliation pass. Dry-run
+fixed draft-only/never-merge policy, and that the target path is a Git worktree
+whose `origin` identifies `target.repository`, without contacting GitHub or
+starting work. Dry-run and live tick perform the same checkout-identity
+preflight before tracker access. `tick` runs one bounded reconciliation pass. Dry-run
 selects and reports eligible work without labels, comments, or worker launch.
 Invalid, tracking, missing-contract, or unresolved-dependency work reports
 `would-block` in dry-run and transitions to blocked only in a live tick.
@@ -58,11 +62,22 @@ than risk descendants surviving after lock release.
 Pi runner configuration accepts optional `timeout-seconds` (default: 7,200) for
 long-running tasks. GitHub CLI calls use a fixed 30-second timeout. Groundskeeper
 does not sandbox a user-authorized Pi process; it enforces its accepted-result
-postcondition by transitioning to review only for an open draft pull request
-with the exact closing reference.
+postcondition by transitioning to review only for an open draft pull request in
+the target repository with the exact repository-qualified source issue closing
+reference. It queries the exact source issue's documented GraphQL
+`closedByPullRequestsReferences` connection, reads each pull request's repository
+identity, and filters to the configured target. It paginates that relevant
+connection and fails closed if its explicit page budget is exhausted. Before
+worker dispatch, an accepted exact open draft reaches review; otherwise an exact
+non-draft, closed, or merged target PR blocks. If accepted and violating target
+PRs coexist, the accepted open draft wins.
 
-All JSON responses use a versioned envelope:
-`{"version":1,"status":"...","data":{...},"exit_code":N}`. Exit `0` means
+All automation JSON responses use the breaking v2 envelope:
+`{"version":2,"status":"...","data":{...},"exit_code":N}`. `list` and `show`
+place complete definitions under `data.automations[]` and `data.automation`;
+`inspect` returns `data.source`, `data.target`, and `data.tasks[]`; and `tick`
+returns `data.source`, `data.target`, its optional repository-qualified
+`data.task`, result detail, PR URL, and session handoff fields. Exit `0` means
 no work, review-ready work, deferred work, or a successful dry-run. In
 particular, `status: "deferred"` is a nonfatal scheduler result. Exit `2` is a
 configuration, command, tracker, or lock error; `4` is claim contention; and `5`

--- a/groundskeeper/adapters/automation_runner.py
+++ b/groundskeeper/adapters/automation_runner.py
@@ -61,12 +61,14 @@ class AutomationSkillRenderer:
         return "\n".join(
             (
                 "AUTOMATION_CONTEXT",
-                f"TASK_ID: {normalized.external_id}",
+                f"TASK_ID: {normalized.source_issue.number}",
                 f"TASK_TITLE: {normalized.title}",
                 "TASK_BODY:",
                 normalized.body,
                 f"TASK_URL: {normalized.url}",
                 f"REPOSITORY: {normalized.target_repository}",
+                "FACTORY_CLOSING_REFERENCE: "
+                f"{normalized.source_issue.closing_reference(normalized.target_repository)}",
                 f"FACTORY_TASK_KIND: {contract.kind.value}",
                 f"FACTORY_EXECUTION_MODE: {contract.mode.value if contract.mode else ''}",
                 "FACTORY_DEPENDENCY_STATUS: resolved",
@@ -97,10 +99,18 @@ class PiAutomationRunner:
         self._config = config
 
     def _settings(self, task: AutomationTask) -> PiExecutionSettings:
-        identity = f"groundskeeper:{task.target_repository}:{task.external_id}"
+        source_repository = task.source_issue.repository.casefold()
+        target_repository = task.target_repository.casefold()
+        identity = (
+            f"groundskeeper:{source_repository}:{task.source_issue.number}:"
+            f"{target_repository}"
+        )
         return PiExecutionSettings(
             session_id=str(uuid.uuid5(uuid.NAMESPACE_URL, identity)),
-            name=f"gk-{task.target_repository.replace('/', '-')}-{task.external_id}",
+            name=(
+                f"gk-{source_repository.replace('/', '-')}-{task.source_issue.number}"
+                f"-to-{target_repository.replace('/', '-')}"
+            ),
             approval=self._config.approval,
             timeout_seconds=self._config.timeout_seconds,
         )

--- a/groundskeeper/adapters/gh.py
+++ b/groundskeeper/adapters/gh.py
@@ -8,10 +8,38 @@ from pathlib import Path
 from typing import cast
 
 from groundskeeper.adapters.process import ProcessClient
+from groundskeeper.domain.automation import (
+    GitHubIssueIdentity,
+    PullRequestReconciliation,
+    canonical_github_repository,
+)
 from groundskeeper.domain.task_contract import DependencyState, GitHubDependency
 
 GH_QUERY_TIMEOUT_SECONDS = 30
 GH_MUTATION_TIMEOUT_SECONDS = 30
+GH_CLOSING_PULL_REQUEST_PAGE_LIMIT = 10
+
+_ISSUE_CLOSING_PULL_REQUESTS_QUERY = """
+query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      closedByPullRequestsReferences(
+        first: 100
+        after: $endCursor
+        includeClosedPrs: true
+      ) {
+        nodes {
+          url
+          isDraft
+          state
+          repository { nameWithOwner }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+""".strip()
 
 
 class GhError(RuntimeError):
@@ -219,115 +247,145 @@ class GhClient:
             f"Dependency issue has unknown state: {dependency.url}",
         )
 
-    def linked_pull_request(self, repository: str, issue: int) -> str | None:
-        result = self._process.run(
-            (
-                "gh",
-                "pr",
-                "list",
-                "--repo",
-                repository,
-                "--state",
-                "open",
-                "--json",
-                "url,isDraft,closingIssuesReferences",
-                "--limit",
-                "1000",
-            ),
-            self._cwd,
-            timeout=GH_QUERY_TIMEOUT_SECONDS,
-        )
-        if not result.success:
-            raise GhError(result.stderr.strip() or "failed to query pull requests")
-        values = self._parse_json(result.stdout, "pull request list")
-        if not isinstance(values, list):
-            raise GhError("gh pr list returned an unexpected JSON shape")
-        try:
-            for pull_request in cast(list[object], values):
-                if not isinstance(pull_request, dict):
-                    raise TypeError
-                pr_data = cast(dict[str, object], pull_request)
-                if pr_data.get("isDraft") is not True:
-                    continue
-                references = pr_data.get("closingIssuesReferences")
-                if not isinstance(references, list):
-                    raise TypeError
-                closes_issue = False
-                for reference in cast(list[object], references):
-                    if not isinstance(reference, dict):
-                        raise TypeError
-                    reference_data = cast(dict[str, object], reference)
-                    number = reference_data.get("number")
-                    if not isinstance(number, (int, str)):
-                        raise TypeError
-                    if int(number) == issue:
-                        closes_issue = True
-                if closes_issue:
-                    return str(pr_data["url"])
-            return None
-        except (KeyError, TypeError, ValueError) as error:
-            raise GhError("gh pr list returned incomplete pull request data") from error
+    def reconcile_pull_requests(
+        self, target_repository: str, source_issue: GitHubIssueIdentity
+    ) -> PullRequestReconciliation:
+        """Read PRs that GitHub records as closing the exact source issue.
 
-    def closing_pr_policy_violation(self, repository: str, issue: int) -> str | None:
-        """Report a closing PR that fails the accepted draft-result postcondition."""
-        result = self._process.run(
-            (
+        The documented issue-rooted connection avoids scanning unrelated target
+        pull requests. An accepted open draft wins if accepted and violating
+        target PRs coexist; otherwise the first target policy violation blocks.
+        """
+        canonical_github_repository(target_repository)
+        owner, name = source_issue.repository.split("/")
+        pull_requests: list[dict[str, object]] = []
+        end_cursor: str | None = None
+        for page_number in range(GH_CLOSING_PULL_REQUEST_PAGE_LIMIT):
+            argv = [
                 "gh",
-                "pr",
-                "list",
-                "--repo",
-                repository,
-                "--state",
-                "all",
-                "--json",
-                "url,isDraft,state,closingIssuesReferences",
-                "--limit",
-                "1000",
-            ),
-            self._cwd,
-            timeout=GH_QUERY_TIMEOUT_SECONDS,
-        )
-        if not result.success:
-            raise GhError(
-                result.stderr.strip() or "failed to query pull request policy"
+                "api",
+                "graphql",
+                "-f",
+                f"query={_ISSUE_CLOSING_PULL_REQUESTS_QUERY}",
+                "-F",
+                f"owner={owner}",
+                "-F",
+                f"name={name}",
+                "-F",
+                f"number={source_issue.number}",
+            ]
+            if end_cursor is not None:
+                argv.extend(("-F", f"endCursor={end_cursor}"))
+            result = self._process.run(
+                tuple(argv), self._cwd, timeout=GH_QUERY_TIMEOUT_SECONDS
             )
-        values = self._parse_json(result.stdout, "pull request policy query")
-        if not isinstance(values, list):
-            raise GhError("gh pr list returned an unexpected JSON shape")
-        try:
-            for pull_request in cast(list[object], values):
-                if not isinstance(pull_request, dict):
-                    raise TypeError
-                pr_data = cast(dict[str, object], pull_request)
-                if not self._closes_issue(pr_data, issue):
-                    continue
-                url = pr_data.get("url")
-                if not isinstance(url, str):
-                    raise TypeError
-                if pr_data.get("isDraft") is not True:
-                    return f"Closing pull request is not a draft: {url}"
-                state = pr_data.get("state")
-                if state != "OPEN":
-                    return f"Closing pull request is not open: {url}"
-            return None
-        except (TypeError, ValueError) as error:
-            raise GhError("gh pr list returned incomplete pull request data") from error
+            if not result.success:
+                raise GhError(
+                    result.stderr.strip() or "failed to query closing pull requests"
+                )
+            page = self._parse_json(result.stdout, "closing pull request GraphQL query")
+            nodes, end_cursor = self._parse_closing_pull_request_page(page)
+            try:
+                pull_requests.extend(
+                    self._parse_closing_pull_request(node) for node in nodes
+                )
+            except (TypeError, ValueError) as error:
+                raise GhError(
+                    "gh GraphQL returned incomplete closing pull request data"
+                ) from error
+            if end_cursor is None:
+                break
+            if page_number == GH_CLOSING_PULL_REQUEST_PAGE_LIMIT - 1:
+                raise GhError(
+                    "closing pull request query exceeded the supported page limit"
+                )
+
+        accepted_url: str | None = None
+        policy_violation: str | None = None
+        for pr_data in pull_requests:
+            repository = cast(str, pr_data["repository"])
+            if repository.casefold() != target_repository.casefold():
+                continue
+            url = cast(str, pr_data["url"])
+            if pr_data["isDraft"] is True and pr_data["state"] == "OPEN":
+                accepted_url = accepted_url or url
+                continue
+            if policy_violation is None:
+                if pr_data["isDraft"] is not True:
+                    policy_violation = f"Closing pull request is not a draft: {url}"
+                else:
+                    policy_violation = f"Closing pull request is not open: {url}"
+        return PullRequestReconciliation(accepted_url, policy_violation)
 
     @staticmethod
-    def _closes_issue(pr_data: dict[str, object], issue: int) -> bool:
-        """Return whether a pull request has the exact closing reference."""
-        references = pr_data.get("closingIssuesReferences")
-        if not isinstance(references, list):
+    def _parse_closing_pull_request_page(
+        value: object,
+    ) -> tuple[list[object], str | None]:
+        try:
+            if not isinstance(value, dict):
+                raise TypeError
+            data = cast(dict[str, object], value).get("data")
+            if not isinstance(data, dict):
+                raise TypeError
+            repository_data = cast(dict[str, object], data).get("repository")
+            if not isinstance(repository_data, dict):
+                raise TypeError
+            issue = cast(dict[str, object], repository_data).get("issue")
+            if not isinstance(issue, dict):
+                raise TypeError
+            connection = cast(dict[str, object], issue).get(
+                "closedByPullRequestsReferences"
+            )
+            if not isinstance(connection, dict):
+                raise TypeError
+            connection_data = cast(dict[str, object], connection)
+            nodes = connection_data.get("nodes")
+            page_info = connection_data.get("pageInfo")
+            if not isinstance(nodes, list) or not isinstance(page_info, dict):
+                raise TypeError
+            page_info_data = cast(dict[str, object], page_info)
+            has_next_page = page_info_data.get("hasNextPage")
+            cursor = page_info_data.get("endCursor")
+            if not isinstance(has_next_page, bool):
+                raise TypeError
+            if has_next_page:
+                if not isinstance(cursor, str) or not cursor:
+                    raise TypeError
+                return cast(list[object], nodes), cursor
+            if cursor is not None and not isinstance(cursor, str):
+                raise TypeError
+            return cast(list[object], nodes), None
+        except (KeyError, TypeError, ValueError) as error:
+            raise GhError(
+                "gh GraphQL returned incomplete closing pull request data"
+            ) from error
+
+    @staticmethod
+    def _parse_closing_pull_request(value: object) -> dict[str, object]:
+        if not isinstance(value, dict):
             raise TypeError
-        for reference in cast(list[object], references):
-            if not isinstance(reference, dict):
-                raise TypeError
-            number = cast(dict[str, object], reference).get("number")
-            if not isinstance(number, (int, str)):
-                raise TypeError
-            if int(number) == issue:
-                return True
-        return False
+        pr_data = cast(dict[str, object], value)
+        url = pr_data.get("url")
+        is_draft = pr_data.get("isDraft")
+        state = pr_data.get("state")
+        repository = pr_data.get("repository")
+        if (
+            not isinstance(url, str)
+            or not isinstance(is_draft, bool)
+            or state not in {"OPEN", "CLOSED", "MERGED"}
+            or not isinstance(repository, dict)
+        ):
+            raise TypeError
+        name_with_owner = cast(dict[str, object], repository).get("nameWithOwner")
+        if not isinstance(name_with_owner, str):
+            raise TypeError
+        canonical_github_repository(name_with_owner)
+        return {
+            "url": url,
+            "isDraft": is_draft,
+            "state": state,
+            "repository": name_with_owner,
+        }
 
     @staticmethod
     def _parse_json(value: str, operation: str) -> object:

--- a/groundskeeper/adapters/github_issues.py
+++ b/groundskeeper/adapters/github_issues.py
@@ -11,6 +11,8 @@ from groundskeeper.domain.automation import (
     AdmittedTask,
     AutomationTask,
     ClaimResult,
+    GitHubIssueIdentity,
+    PullRequestReconciliation,
     TaskState,
 )
 from groundskeeper.domain.config import GitHubIssuesSource
@@ -23,9 +25,12 @@ from groundskeeper.domain.task_contract import (
 
 
 class GitHubIssuesTracker:
-    def __init__(self, client: GhClient, source: GitHubIssuesSource) -> None:
+    def __init__(
+        self, client: GhClient, source: GitHubIssuesSource, target_repository: str
+    ) -> None:
         self._client = client
         self._source = source
+        self._target_repository = target_repository
 
     def list_ready(self) -> list[AutomationTask]:
         return self._list_in_state(self._source.ready_label, TaskState.READY)
@@ -47,18 +52,20 @@ class GitHubIssuesTracker:
     def _task_from_issue(self, issue: GhIssue, state: TaskState) -> AutomationTask:
         return AutomationTask(
             provider="github-issues",
-            external_id=str(issue.number),
             title=issue.title,
             body=issue.body,
             url=issue.url,
             author=issue.author,
-            target_repository=self._source.repository,
+            source_issue=GitHubIssueIdentity(self._source.repository, issue.number),
+            target_repository=self._target_repository,
             state=state,
         )
 
     def refresh(self, task: AutomationTask) -> AutomationTask:
         """Read and verify the current task immediately before execution."""
-        issue = self._client.get_issue(self._source.repository, int(task.external_id))
+        issue = self._client.get_issue(
+            self._source.repository, task.source_issue.number
+        )
         if issue.author not in self._source.trusted_authors:
             raise RuntimeError("task author is no longer trusted")
         if issue.state != "open":
@@ -119,13 +126,13 @@ class GitHubIssuesTracker:
                 False, task, f"task cannot be claimed from {task.state.value}"
             )
         list_tasks, source_label = queue
-        current = {item.external_id: item for item in list_tasks()}
-        current_task = current.get(task.external_id)
+        current = {item.source_issue.number: item for item in list_tasks()}
+        current_task = current.get(task.source_issue.number)
         if current_task is None:
             return ClaimResult(False, task, f"task is no longer {task.state.value}")
         self._client.replace_label(
             self._source.repository,
-            int(task.external_id),
+            task.source_issue.number,
             source_label,
             self._source.running_label,
         )
@@ -153,21 +160,18 @@ class GitHubIssuesTracker:
             TaskState.BLOCKED: self._source.blocked_label,
         }[task.state]
         self._client.replace_label(
-            self._source.repository, int(task.external_id), old, target
+            self._source.repository, task.source_issue.number, old, target
         )
         if detail:
             self._client.comment(
                 self._source.repository,
-                int(task.external_id),
+                task.source_issue.number,
                 f"AI-authored factory update: {detail}",
             )
 
-    def find_pull_request(self, task: AutomationTask) -> str | None:
-        return self._client.linked_pull_request(
-            self._source.repository, int(task.external_id)
-        )
-
-    def find_policy_violation(self, task: AutomationTask) -> str | None:
-        return self._client.closing_pr_policy_violation(
-            self._source.repository, int(task.external_id)
+    def reconcile_pull_requests(
+        self, task: AutomationTask
+    ) -> PullRequestReconciliation:
+        return self._client.reconcile_pull_requests(
+            task.target_repository, task.source_issue
         )

--- a/groundskeeper/adapters/target_checkout.py
+++ b/groundskeeper/adapters/target_checkout.py
@@ -1,0 +1,74 @@
+"""Preflight validation for a configured automation target checkout."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from urllib.parse import urlparse
+
+from groundskeeper.adapters.process import ProcessClient
+from groundskeeper.domain.automation import canonical_github_repository
+
+GIT_PREFLIGHT_TIMEOUT_SECONDS = 30
+_SCP_GITHUB_REMOTE_RE = re.compile(r"^git@github\.com:(?P<repository>[^/]+/[^/]+)$")
+
+
+class TargetCheckoutError(RuntimeError):
+    """The configured target path does not identify the declared repository."""
+
+
+def _repository_from_remote(remote: str) -> str:
+    """Return canonical owner/repo identity from a normal GitHub remote URL."""
+    value = remote.strip()
+    if value.endswith(".git"):
+        value = value[:-4]
+    scp_match = _SCP_GITHUB_REMOTE_RE.fullmatch(value)
+    if scp_match:
+        candidate = scp_match.group("repository")
+    else:
+        parsed = urlparse(value)
+        if parsed.scheme not in {"https", "ssh"} or parsed.hostname != "github.com":
+            raise TargetCheckoutError(
+                "target checkout origin must be a GitHub HTTPS or SSH remote"
+            )
+        if parsed.scheme == "ssh" and parsed.username != "git":
+            raise TargetCheckoutError(
+                "target checkout origin must use the GitHub SSH git user"
+            )
+        candidate = parsed.path.removeprefix("/")
+    try:
+        return canonical_github_repository(candidate)
+    except ValueError as error:
+        raise TargetCheckoutError(
+            "target checkout origin does not contain a canonical owner/repo identity"
+        ) from error
+
+
+def validate_target_checkout(
+    process: ProcessClient, repository_path: Path, expected_repository: str
+) -> None:
+    """Prove the target path is a Git worktree for the configured origin."""
+    worktree = process.run(
+        ("git", "rev-parse", "--is-inside-work-tree"),
+        repository_path,
+        timeout=GIT_PREFLIGHT_TIMEOUT_SECONDS,
+    )
+    if not worktree.success or worktree.stdout.strip() != "true":
+        raise TargetCheckoutError(
+            f"target.repository-path is not a Git worktree: {repository_path}"
+        )
+    origin = process.run(
+        ("git", "remote", "get-url", "origin"),
+        repository_path,
+        timeout=GIT_PREFLIGHT_TIMEOUT_SECONDS,
+    )
+    if not origin.success or not origin.stdout.strip():
+        raise TargetCheckoutError(
+            f"target repository has no configured origin remote: {repository_path}"
+        )
+    actual_repository = _repository_from_remote(origin.stdout)
+    if actual_repository.casefold() != expected_repository.casefold():
+        raise TargetCheckoutError(
+            "target checkout origin repository does not match target.repository: "
+            f"expected {expected_repository}, found {actual_repository}"
+        )

--- a/groundskeeper/adapters/target_checkout.py
+++ b/groundskeeper/adapters/target_checkout.py
@@ -10,7 +10,9 @@ from groundskeeper.adapters.process import ProcessClient
 from groundskeeper.domain.automation import canonical_github_repository
 
 GIT_PREFLIGHT_TIMEOUT_SECONDS = 30
-_SCP_GITHUB_REMOTE_RE = re.compile(r"^git@github\.com:(?P<repository>[^/]+/[^/]+)$")
+_SCP_GITHUB_REMOTE_RE = re.compile(
+    r"^[^@/:]+@github\.com:(?P<repository>[^/]+/[^/]+)$"
+)
 
 
 class TargetCheckoutError(RuntimeError):
@@ -30,10 +32,6 @@ def _repository_from_remote(remote: str) -> str:
         if parsed.scheme not in {"https", "ssh"} or parsed.hostname != "github.com":
             raise TargetCheckoutError(
                 "target checkout origin must be a GitHub HTTPS or SSH remote"
-            )
-        if parsed.scheme == "ssh" and parsed.username != "git":
-            raise TargetCheckoutError(
-                "target checkout origin must use the GitHub SSH git user"
             )
         candidate = parsed.path.removeprefix("/")
     try:

--- a/groundskeeper/adapters/target_checkout.py
+++ b/groundskeeper/adapters/target_checkout.py
@@ -10,9 +10,7 @@ from groundskeeper.adapters.process import ProcessClient
 from groundskeeper.domain.automation import canonical_github_repository
 
 GIT_PREFLIGHT_TIMEOUT_SECONDS = 30
-_SCP_GITHUB_REMOTE_RE = re.compile(
-    r"^[^@/:]+@github\.com:(?P<repository>[^/]+/[^/]+)$"
-)
+_SCP_GITHUB_REMOTE_RE = re.compile(r"^[^@/:]+@github\.com:(?P<repository>[^/]+/[^/]+)$")
 
 
 class TargetCheckoutError(RuntimeError):

--- a/groundskeeper/automation.py
+++ b/groundskeeper/automation.py
@@ -64,18 +64,31 @@ class AutomationService:
                 return TickResult(
                     automation.name, "not-claimed", task, detail=str(error)
                 )
-            try:
-                existing_pr = self._tracker.find_pull_request(task)
-            except RuntimeError as error:
-                return self._block(automation.name, task, str(error))
-            if existing_pr:
+            reconciliation = self._tracker.reconcile_pull_requests(task)
+            if reconciliation.accepted_url:
                 if dry_run:
-                    return TickResult(automation.name, "review", task, existing_pr)
+                    return TickResult(
+                        automation.name,
+                        "review",
+                        task,
+                        reconciliation.accepted_url,
+                    )
                 return self._review(
                     automation.name,
                     task,
-                    existing_pr,
+                    reconciliation.accepted_url,
                     _work_result_for_session(self._runner.session_metadata(task)),
+                )
+            if reconciliation.policy_violation:
+                if dry_run:
+                    return TickResult(
+                        automation.name,
+                        "would-block",
+                        task,
+                        detail=reconciliation.policy_violation,
+                    )
+                return self._block(
+                    automation.name, task, reconciliation.policy_violation
                 )
             admission = self._tracker.admit(task)
             if not admission.eligible:
@@ -97,6 +110,9 @@ class AutomationService:
         deferred = self._tracker.list_deferred()
         if deferred:
             task = deferred[0]
+            reconciled = self._before_dispatch(automation.name, task, dry_run)
+            if reconciled is not None:
+                return reconciled
             if dry_run:
                 admission = self._tracker.admit(task)
                 if not admission.eligible:
@@ -113,6 +129,9 @@ class AutomationService:
         if not ready:
             return TickResult(automation.name, "no-work")
         task = ready[0]
+        reconciled = self._before_dispatch(automation.name, task, dry_run)
+        if reconciled is not None:
+            return reconciled
         if dry_run:
             admission = self._tracker.admit(task)
             if not admission.eligible:
@@ -132,17 +151,9 @@ class AutomationService:
         claim = self._tracker.claim(task)
         if not claim.claimed:
             return TickResult(name, "not-claimed", task, detail=claim.reason)
-        try:
-            existing_pr = self._tracker.find_pull_request(claim.task)
-        except RuntimeError as error:
-            return self._block(name, claim.task, str(error))
-        if existing_pr:
-            return self._review(
-                name,
-                claim.task,
-                existing_pr,
-                _work_result_for_session(self._runner.session_metadata(claim.task)),
-            )
+        reconciled = self._before_dispatch(name, claim.task, False)
+        if reconciled is not None:
+            return reconciled
         admission = self._tracker.admit(claim.task)
         if not admission.eligible:
             return self._block(name, claim.task, admission.reason)
@@ -151,20 +162,40 @@ class AutomationService:
         result = self._runner.run(admitted, recovery=recovery)
         return self._finish(name, admitted_task, result)
 
+    def _before_dispatch(
+        self, name: str, task: AutomationTask, dry_run: bool
+    ) -> TickResult | None:
+        """Reconcile exact closing PR policy before any worker process starts."""
+        reconciliation = self._tracker.reconcile_pull_requests(task)
+        if reconciliation.accepted_url:
+            if dry_run:
+                return TickResult(name, "review", task, reconciliation.accepted_url)
+            return self._review(
+                name,
+                task,
+                reconciliation.accepted_url,
+                _work_result_for_session(self._runner.session_metadata(task)),
+            )
+        if reconciliation.policy_violation:
+            if dry_run:
+                return TickResult(
+                    name,
+                    "would-block",
+                    task,
+                    detail=reconciliation.policy_violation,
+                )
+            return self._block(name, task, reconciliation.policy_violation)
+        return None
+
     def _finish(
         self, name: str, task: AutomationTask, result: WorkResult
     ) -> TickResult:
         """Reconcile durable GitHub state before trusting worker process status."""
-        try:
-            pr_url = self._tracker.find_pull_request(task)
-            if pr_url:
-                return self._review(name, task, pr_url, result)
-            violation = self._tracker.find_policy_violation(task)
-        except RuntimeError as error:
-            return self._block(name, task, str(error), result)
-
-        if violation is not None:
-            return self._block(name, task, violation, result)
+        reconciliation = self._tracker.reconcile_pull_requests(task)
+        if reconciliation.accepted_url:
+            return self._review(name, task, reconciliation.accepted_url, result)
+        if reconciliation.policy_violation is not None:
+            return self._block(name, task, reconciliation.policy_violation, result)
         if not result.success:
             detail = result.error.strip() or f"worker exited {result.exit_code}"
             if result.failure_disposition is FailureDisposition.DEFERRED:

--- a/groundskeeper/cli/main.py
+++ b/groundskeeper/cli/main.py
@@ -24,6 +24,7 @@ from groundskeeper.adapters.github_issues import GitHubIssuesTracker
 from groundskeeper.adapters.local_store import LocalSkillStore
 from groundskeeper.adapters.pi import PiClient
 from groundskeeper.adapters.process import ProcessClient
+from groundskeeper.adapters.target_checkout import validate_target_checkout
 from groundskeeper.adapters.tick_lock import TickLock
 from groundskeeper.automation import AutomationService
 from groundskeeper.domain.config import (
@@ -93,7 +94,7 @@ def cli(ctx: click.Context, skill_path: tuple[str, ...]) -> None:
     ctx.obj["extra_skill_paths"] = skill_path
 
 
-JSON_VERSION = 1
+JSON_VERSION = 2
 
 
 class AutomationCommandError(click.ClickException):
@@ -153,14 +154,21 @@ def _automation_summary(
     """Return a stable, compact automation description."""
     summary: dict[str, object] = {
         "name": item.name,
-        "repository": item.source.repository,
-        "repository_path": str(item.source.repository_path),
-        "labels": {
-            "ready": item.source.ready_label,
-            "running": item.source.running_label,
-            "deferred": item.source.deferred_label,
-            "review": item.source.review_label,
-            "blocked": item.source.blocked_label,
+        "source": {
+            "type": "github-issues",
+            "repository": item.source.repository,
+            "trusted_authors": list(item.source.trusted_authors),
+            "labels": {
+                "ready": item.source.ready_label,
+                "running": item.source.running_label,
+                "deferred": item.source.deferred_label,
+                "review": item.source.review_label,
+                "blocked": item.source.blocked_label,
+            },
+        },
+        "target": {
+            "repository": item.target.repository,
+            "repository_path": str(item.target.repository_path),
         },
         "runner": {
             "type": item.runner.type,
@@ -227,7 +235,7 @@ def _automation_state_root() -> Path:
 
 def _automation_lock_path(definition: Automation) -> Path:
     """Return a stable host-local lock shared by one normalized repository."""
-    repository_identity = definition.source.repository.strip().casefold()
+    repository_identity = definition.source.repository.casefold()
     repository_key = hashlib.sha256(repository_identity.encode("utf-8")).hexdigest()[
         :16
     ]
@@ -259,12 +267,13 @@ def _build_automation_runner(
     skill: Skill | None = None,
 ) -> PiAutomationRunner:
     """Construct the one supported typed automation runner after preflight checks."""
-    repository_path = definition.source.repository_path
+    repository_path = definition.target.repository_path
     if not repository_path.is_dir():
         raise ConfigError(
             f"Automation '{definition.name}' repository path does not exist: "
             f"{repository_path}"
         )
+    validate_target_checkout(process, repository_path, definition.target.repository)
     resolved_skill = skill or _resolve_automation_skill(
         definition, config_path, extra_skill_paths
     )
@@ -396,7 +405,7 @@ def automation_validate(
                 item, config_path, extra, ProcessClient(), skill=skill
             )
             summaries.append(_automation_summary(item, skill))
-    except ConfigError as error:
+    except (ConfigError, RuntimeError) as error:
         _automation_error(str(error), json_output)
         return
     data = {"automations": summaries}
@@ -426,7 +435,9 @@ def automation_inspect(ctx: click.Context, name: str, json_output: bool) -> None
         definition = _load_automation(config_path, name)
         process = ProcessClient()
         tracker = GitHubIssuesTracker(
-            GhClient(process, definition.source.repository_path), definition.source
+            GhClient(process, definition.target.repository_path),
+            definition.source,
+            definition.target.repository,
         )
         tasks = [
             *tracker.list_running(),
@@ -439,7 +450,12 @@ def automation_inspect(ctx: click.Context, name: str, json_output: bool) -> None
             contract = admission.task.contract
             records.append(
                 {
-                    "id": task.external_id,
+                    "id": str(task.source_issue.number),
+                    "source": {
+                        "repository": task.source_issue.repository,
+                        "issue": task.source_issue.number,
+                    },
+                    "target": {"repository": task.target_repository},
                     "title": task.title,
                     "url": task.url,
                     "state": task.state.value,
@@ -462,7 +478,15 @@ def automation_inspect(ctx: click.Context, name: str, json_output: bool) -> None
     except (ConfigError, RuntimeError) as error:
         _automation_error(str(error), json_output)
         return
-    data = {"automation": name, "tasks": records}
+    data = {
+        "automation": name,
+        "source": {"repository": definition.source.repository},
+        "target": {
+            "repository": definition.target.repository,
+            "repository_path": str(definition.target.repository_path),
+        },
+        "tasks": records,
+    }
     if json_output:
         click.echo(_automation_envelope("ok", data))
         return
@@ -503,7 +527,9 @@ def automation_tick(
             definition, config_path, extra, process, require_available=not dry_run
         )
         tracker = GitHubIssuesTracker(
-            GhClient(process, definition.source.repository_path), definition.source
+            GhClient(process, definition.target.repository_path),
+            definition.source,
+            definition.target.repository,
         )
         lock_path = _automation_lock_path(definition)
         with TickLock(lock_path):
@@ -517,14 +543,23 @@ def automation_tick(
     task_data = None
     if result.task is not None:
         task_data = {
-            "id": result.task.external_id,
+            "id": str(result.task.source_issue.number),
             "title": result.task.title,
             "url": result.task.url,
-            "repository": result.task.target_repository,
+            "source": {
+                "repository": result.task.source_issue.repository,
+                "issue": result.task.source_issue.number,
+            },
+            "target": {"repository": result.task.target_repository},
             "state": result.task.state.value,
         }
     data: dict[str, object] = {
         "automation": result.automation,
+        "source": {"repository": definition.source.repository},
+        "target": {
+            "repository": definition.target.repository,
+            "repository_path": str(definition.target.repository_path),
+        },
         "task": task_data,
         "pull_request_url": result.pull_request_url,
         "detail": result.detail,

--- a/groundskeeper/cli/main.py
+++ b/groundskeeper/cli/main.py
@@ -531,11 +531,13 @@ def automation_tick(
             definition.source,
             definition.target.repository,
         )
-        lock_path = _automation_lock_path(definition)
-        with TickLock(lock_path):
-            result = AutomationService(tracker, runner).tick(
-                definition, dry_run=dry_run
-            )
+        service = AutomationService(tracker, runner)
+        if dry_run:
+            result = service.tick(definition, dry_run=True)
+        else:
+            lock_path = _automation_lock_path(definition)
+            with TickLock(lock_path):
+                result = service.tick(definition, dry_run=False)
     except (ConfigError, RuntimeError) as error:
         _automation_error(str(error), json_output)
         return

--- a/groundskeeper/domain/automation.py
+++ b/groundskeeper/domain/automation.py
@@ -2,10 +2,22 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from enum import Enum
 
 from groundskeeper.domain.task_contract import FactoryTaskContract
+
+_GITHUB_REPOSITORY_RE = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?/[A-Za-z0-9_.-]+"
+)
+
+
+def canonical_github_repository(value: str) -> str:
+    """Validate and return one canonical GitHub owner/repo identity."""
+    if not _GITHUB_REPOSITORY_RE.fullmatch(value):
+        raise ValueError("GitHub repository identity must be canonical owner/repo")
+    return value
 
 
 class TaskState(str, Enum):
@@ -19,15 +31,43 @@ class TaskState(str, Enum):
 
 
 @dataclass(frozen=True)
+class GitHubIssueIdentity:
+    """Repository-qualified identity of one source queue issue."""
+
+    repository: str
+    number: int
+
+    def __post_init__(self) -> None:
+        canonical_github_repository(self.repository)
+        if isinstance(self.number, bool) or self.number <= 0:
+            raise ValueError("GitHub issue number must be positive")
+
+    def closing_reference(self, target_repository: str) -> str:
+        """Render the GitHub closing syntax required in the target pull request."""
+        canonical_github_repository(target_repository)
+        if self.repository.casefold() == target_repository.casefold():
+            return f"#{self.number}"
+        return f"{self.repository}#{self.number}"
+
+
+@dataclass(frozen=True)
+class PullRequestReconciliation:
+    """One coherent source-issue closing-PR snapshot in the target repository."""
+
+    accepted_url: str | None = None
+    policy_violation: str | None = None
+
+
+@dataclass(frozen=True)
 class AutomationTask:
     """A unit of work normalized from an external tracker."""
 
     provider: str
-    external_id: str
     title: str
     body: str
     url: str
     author: str
+    source_issue: GitHubIssueIdentity
     target_repository: str
     state: TaskState = TaskState.READY
     contract: FactoryTaskContract | None = None

--- a/groundskeeper/domain/config.py
+++ b/groundskeeper/domain/config.py
@@ -10,6 +10,7 @@ from typing import Any, Literal, cast
 
 import yaml
 
+from groundskeeper.domain.automation import canonical_github_repository
 from groundskeeper.domain.errors import ConfigError
 from groundskeeper.domain.triggers import (
     EventTrigger,
@@ -131,13 +132,20 @@ class GitHubIssuesSource:
     """GitHub-specific queue configuration confined to its adapter."""
 
     repository: str
-    repository_path: Path
     trusted_authors: tuple[str, ...]
     ready_label: str = "factory:ready"
     running_label: str = "factory:running"
     review_label: str = "factory:review"
     blocked_label: str = "factory:blocked"
     deferred_label: str = "factory:deferred"
+
+
+@dataclass(frozen=True)
+class AutomationTarget:
+    """Repository and checkout where the implementation worker runs."""
+
+    repository: str
+    repository_path: Path
 
 
 @dataclass(frozen=True)
@@ -166,6 +174,7 @@ class Automation:
 
     name: str
     source: GitHubIssuesSource
+    target: AutomationTarget
     runner: PiRunnerConfig
     policy: AutomationPolicy = field(default_factory=AutomationPolicy)
 
@@ -353,9 +362,10 @@ def get_automations(config: Mapping[str, object]) -> list[Automation]:
         entry_path = f"automations.{name}"
         value = _automation_mapping(value, entry_path)
         _reject_unknown_automation_keys(
-            value, {"source", "runner", "policy"}, entry_path
+            value, {"source", "target", "runner", "policy"}, entry_path
         )
         source = value.get("source")
+        target = value.get("target")
         runner = value.get("runner")
         policy = value.get("policy", {})
         if not isinstance(source, dict):
@@ -369,8 +379,16 @@ def get_automations(config: Mapping[str, object]) -> list[Automation]:
             )
         _reject_unknown_automation_keys(
             source,
-            {"type", "repository", "repository-path", "trusted-authors", "labels"},
+            {"type", "repository", "trusted-authors", "labels"},
             f"{entry_path}.source",
+        )
+        if not isinstance(target, dict):
+            raise ConfigError(f"Automation '{name}' requires target")
+        target = _automation_mapping(target, f"{entry_path}.target")
+        _reject_unknown_automation_keys(
+            target,
+            {"repository", "repository-path"},
+            f"{entry_path}.target",
         )
         if not isinstance(runner, dict):
             raise ConfigError(f"Automation '{name}' requires runner.type: pi")
@@ -408,13 +426,28 @@ def get_automations(config: Mapping[str, object]) -> list[Automation]:
             f"{entry_path}.policy",
             {"concurency": "concurrency"},
         )
-        repository = source.get("repository")
-        repository_path = source.get("repository-path")
+        source_repository = source.get("repository")
+        target_repository = target.get("repository")
+        repository_path = target.get("repository-path")
         authors = source.get("trusted-authors")
-        if not isinstance(repository, str) or not repository:
+        if not isinstance(source_repository, str) or not source_repository:
             raise ConfigError(f"Automation '{name}' requires source.repository")
+        if not isinstance(target_repository, str) or not target_repository:
+            raise ConfigError(f"Automation '{name}' requires target.repository")
+        try:
+            source_repository = canonical_github_repository(source_repository)
+        except ValueError as error:
+            raise ConfigError(
+                f"Automation '{name}' source.repository must be canonical owner/repo"
+            ) from error
+        try:
+            target_repository = canonical_github_repository(target_repository)
+        except ValueError as error:
+            raise ConfigError(
+                f"Automation '{name}' target.repository must be canonical owner/repo"
+            ) from error
         if not isinstance(repository_path, str) or not repository_path:
-            raise ConfigError(f"Automation '{name}' requires source.repository-path")
+            raise ConfigError(f"Automation '{name}' requires target.repository-path")
         if (
             not isinstance(authors, list)
             or not authors
@@ -457,20 +490,23 @@ def get_automations(config: Mapping[str, object]) -> list[Automation]:
         path = Path(repository_path).expanduser()
         if not path.is_absolute():
             raise ConfigError(
-                f"Automation '{name}' source.repository-path must be absolute"
+                f"Automation '{name}' target.repository-path must be absolute"
             )
         automations.append(
             Automation(
                 name=str(name),
                 source=GitHubIssuesSource(
-                    repository=repository,
-                    repository_path=path.resolve(),
+                    repository=source_repository,
                     trusted_authors=tuple(cast(list[str], authors)),
                     ready_label=resolved_labels["ready"],
                     running_label=resolved_labels["running"],
                     review_label=resolved_labels["review"],
                     blocked_label=resolved_labels["blocked"],
                     deferred_label=resolved_labels["deferred"],
+                ),
+                target=AutomationTarget(
+                    repository=target_repository,
+                    repository_path=path.resolve(),
                 ),
                 runner=PiRunnerConfig(skill=skill, timeout_seconds=timeout_seconds),
                 policy=AutomationPolicy(),

--- a/groundskeeper/protocols.py
+++ b/groundskeeper/protocols.py
@@ -9,6 +9,7 @@ from groundskeeper.domain.automation import (
     AdmittedTask,
     AutomationTask,
     ClaimResult,
+    PullRequestReconciliation,
     SessionMetadata,
     TaskState,
     WorkResult,
@@ -60,8 +61,9 @@ class Tracker(Protocol):
     def transition(
         self, task: AutomationTask, state: TaskState, detail: str = ""
     ) -> None: ...
-    def find_pull_request(self, task: AutomationTask) -> str | None: ...
-    def find_policy_violation(self, task: AutomationTask) -> str | None: ...
+    def reconcile_pull_requests(
+        self, task: AutomationTask
+    ) -> PullRequestReconciliation: ...
 
 
 class AutomationRunner(Protocol):

--- a/tests/adapters/test_gh.py
+++ b/tests/adapters/test_gh.py
@@ -1,25 +1,67 @@
+import json
 from pathlib import Path
 
 import pytest
 
 from groundskeeper.adapters.gh import GH_QUERY_TIMEOUT_SECONDS, GhClient, GhError
 from groundskeeper.adapters.process import CommandResult
+from groundskeeper.domain.automation import GitHubIssueIdentity
 from groundskeeper.domain.task_contract import DependencyState, GitHubDependency
 
 
 class FakeProcess:
-    def __init__(self, stdout: str, success: bool = True) -> None:
-        self.stdout = stdout
+    def __init__(self, stdout: str | list[str], success: bool = True) -> None:
+        self.stdout = [stdout] if isinstance(stdout, str) else stdout
         self.success = success
         self.argv: tuple[str, ...] = ()
+        self.argv_history: list[tuple[str, ...]] = []
         self.timeout: int | None = None
 
     def run(
         self, argv: tuple[str, ...], cwd: Path, timeout: int | None = None
     ) -> CommandResult:
         self.argv = argv
+        self.argv_history.append(argv)
         self.timeout = timeout
-        return CommandResult(argv, cwd, 0 if self.success else 1, self.stdout, "")
+        stdout = self.stdout[min(len(self.argv_history) - 1, len(self.stdout) - 1)]
+        return CommandResult(argv, cwd, 0 if self.success else 1, stdout, "")
+
+
+def _graphql_page(
+    pull_requests: list[dict[str, object]], *, end_cursor: str | None = None
+) -> str:
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "closedByPullRequestsReferences": {
+                            "nodes": pull_requests,
+                            "pageInfo": {
+                                "hasNextPage": end_cursor is not None,
+                                "endCursor": end_cursor,
+                            },
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+
+def _pr(
+    url: str,
+    repository: str,
+    *,
+    draft: bool = True,
+    state: str = "OPEN",
+) -> dict[str, object]:
+    return {
+        "url": url,
+        "isDraft": draft,
+        "state": state,
+        "repository": {"nameWithOwner": repository},
+    }
 
 
 def test_invalid_json_is_actionable() -> None:
@@ -106,51 +148,110 @@ def test_dependency_state_reports_inaccessible_without_parsing_error() -> None:
     assert dependency.url in reason
 
 
-def test_linked_pr_matches_exact_closing_issue_reference() -> None:
+def test_reconciliation_is_rooted_at_exact_source_issue_and_filters_target() -> None:
     process = FakeProcess(
-        '[{"url":"https://pr/incidental","isDraft":true,"closingIssuesReferences":[{"number":112}]},'
-        '{"url":"https://pr/exact","isDraft":true,"closingIssuesReferences":[{"number":12}]}]'
+        _graphql_page(
+            [
+                _pr("https://pr/other", "other/repo"),
+                _pr("https://pr/exact", "target/repo"),
+            ]
+        )
     )
-    assert (
-        GhClient(process, Path(".")).linked_pull_request("me/repo", 12)
-        == "https://pr/exact"
+
+    result = GhClient(process, Path(".")).reconcile_pull_requests(
+        "target/repo", GitHubIssueIdentity("source/queue", 12)
     )
-    assert any("closingIssuesReferences" in argument for argument in process.argv)
-    assert "--search" not in process.argv
-    assert process.argv[process.argv.index("--limit") + 1] == "1000"
+
+    assert result.accepted_url == "https://pr/exact"
+    assert result.policy_violation is None
+    assert process.argv[:3] == ("gh", "api", "graphql")
+    assert "owner=source" in process.argv
+    assert "name=queue" in process.argv
+    assert "number=12" in process.argv
+    assert "includeClosedPrs: true" in process.argv[process.argv.index("-f") + 1]
 
 
-def test_linked_pr_finds_exact_reference_after_first_hundred() -> None:
-    unrelated = ",".join(
-        f'{{"url":"https://pr/{number}","isDraft":true,"closingIssuesReferences":[{{"number":{number + 1000}}}]}}'
-        for number in range(150)
-    )
+def test_reconciliation_reads_all_issue_closing_pr_pages() -> None:
     process = FakeProcess(
-        f'[{unrelated},{{"url":"https://pr/exact","isDraft":true,'
-        '"closingIssuesReferences":[{"number":12}]}]'
-    )
-    assert (
-        GhClient(process, Path(".")).linked_pull_request("me/repo", 12)
-        == "https://pr/exact"
+        [
+            _graphql_page([], end_cursor="next-page"),
+            _graphql_page([_pr("https://pr/exact", "target/repo")]),
+        ]
     )
 
+    result = GhClient(process, Path(".")).reconcile_pull_requests(
+        "target/repo", GitHubIssueIdentity("source/queue", 12)
+    )
 
-def test_closing_non_draft_or_merged_pr_is_a_policy_violation() -> None:
+    assert result.accepted_url == "https://pr/exact"
+    assert len(process.argv_history) == 2
+    assert "endCursor=next-page" in process.argv_history[1]
+
+
+def test_reconciliation_fails_closed_when_page_limit_is_exhausted() -> None:
+    pages = [_graphql_page([], end_cursor=f"page-{number}") for number in range(10)]
+    client = GhClient(FakeProcess(pages), Path("."))
+
+    with pytest.raises(GhError):
+        client.reconcile_pull_requests(
+            "target/repo", GitHubIssueIdentity("source/queue", 12)
+        )
+
+
+@pytest.mark.parametrize(
+    ("draft", "state", "expected"),
+    [
+        (False, "OPEN", "not a draft"),
+        (True, "CLOSED", "not open"),
+        (True, "MERGED", "not open"),
+    ],
+)
+def test_exact_target_non_draft_or_closed_pr_is_policy_violation(
+    draft: bool, state: str, expected: str
+) -> None:
     process = FakeProcess(
-        '[{"url":"https://pr/ready","isDraft":false,"state":"OPEN",'
-        '"closingIssuesReferences":[{"number":12}]},'
-        '{"url":"https://pr/merged","isDraft":false,"state":"MERGED",'
-        '"closingIssuesReferences":[{"number":12}]}]'
+        _graphql_page(
+            [_pr("https://pr/invalid", "target/repo", draft=draft, state=state)]
+        )
     )
-    violation = GhClient(process, Path(".")).closing_pr_policy_violation("me/repo", 12)
-    assert violation == "Closing pull request is not a draft: https://pr/ready"
-    assert "--state" in process.argv
-    assert process.argv[process.argv.index("--state") + 1] == "all"
+
+    result = GhClient(process, Path(".")).reconcile_pull_requests(
+        "target/repo", GitHubIssueIdentity("source/queue", 12)
+    )
+
+    assert result.policy_violation is not None
+    assert expected in result.policy_violation
 
 
-def test_linked_pr_ignores_non_draft_closing_reference() -> None:
+def test_reconciliation_reports_accepted_and_violating_coexistence() -> None:
     process = FakeProcess(
-        '[{"url":"https://pr/ready","isDraft":false,'
-        '"closingIssuesReferences":[{"number":12}]}]'
+        _graphql_page(
+            [
+                _pr("https://pr/violation", "target/repo", draft=False),
+                _pr("https://pr/accepted", "target/repo"),
+            ]
+        )
     )
-    assert GhClient(process, Path(".")).linked_pull_request("me/repo", 12) is None
+
+    result = GhClient(process, Path(".")).reconcile_pull_requests(
+        "target/repo", GitHubIssueIdentity("source/queue", 12)
+    )
+
+    assert result.accepted_url == "https://pr/accepted"
+    assert result.policy_violation is not None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        _graphql_page(
+            [{"url": "https://pr/incomplete", "isDraft": True, "state": "OPEN"}]
+        ),
+        json.dumps({"data": {"repository": {"issue": None}}}),
+    ],
+)
+def test_incomplete_closing_pull_request_payload_is_rejected(payload: str) -> None:
+    with pytest.raises(GhError):
+        GhClient(FakeProcess(payload), Path(".")).reconcile_pull_requests(
+            "target/repo", GitHubIssueIdentity("source/queue", 12)
+        )

--- a/tests/adapters/test_github_issues.py
+++ b/tests/adapters/test_github_issues.py
@@ -1,11 +1,14 @@
 from dataclasses import replace
-from pathlib import Path
 
 import pytest
 
 from groundskeeper.adapters.gh import GhIssue
 from groundskeeper.adapters.github_issues import GitHubIssuesTracker
-from groundskeeper.domain.automation import AdmissionState, TaskState
+from groundskeeper.domain.automation import (
+    AdmissionState,
+    PullRequestReconciliation,
+    TaskState,
+)
 from groundskeeper.domain.config import GitHubIssuesSource
 from groundskeeper.domain.task_contract import DependencyState, GitHubDependency
 
@@ -36,8 +39,11 @@ class FakeGhClient:
         ]
         self.labels: list[tuple[int, str, str]] = []
         self.comments: list[tuple[int, str]] = []
+        self.issue_repositories: list[str] = []
+        self.pull_request_repositories: list[str] = []
 
     def list_issues(self, repository: str, labels: tuple[str, ...]) -> list[GhIssue]:
+        self.issue_repositories.append(repository)
         return [
             item
             for item in self.issues
@@ -45,9 +51,11 @@ class FakeGhClient:
         ]
 
     def get_issue(self, repository: str, issue: int) -> GhIssue:
+        self.issue_repositories.append(repository)
         return next(item for item in self.issues if item.number == issue)
 
     def replace_label(self, repository: str, issue: int, old: str, new: str) -> None:
+        self.issue_repositories.append(repository)
         self.labels.append((issue, old, new))
         self.issues = [
             replace(
@@ -60,6 +68,7 @@ class FakeGhClient:
         ]
 
     def comment(self, repository: str, issue: int, body: str) -> None:
+        self.issue_repositories.append(repository)
         self.comments.append((issue, body))
 
     def dependency_state(
@@ -67,27 +76,36 @@ class FakeGhClient:
     ) -> tuple[DependencyState, str]:
         return DependencyState.COMPLETE, ""
 
-    def linked_pull_request(self, repository: str, issue: int) -> str | None:
-        return None
+    def reconcile_pull_requests(
+        self, repository: str, source_issue: object
+    ) -> PullRequestReconciliation:
+        self.pull_request_repositories.append(repository)
+        return PullRequestReconciliation()
 
 
 def test_filters_untrusted_authors_and_claim_is_idempotent() -> None:
     client = FakeGhClient()
-    source = GitHubIssuesSource("me/dots", Path("/tmp/dots"), ("alex",))
-    tracker = GitHubIssuesTracker(client, source)
+    source = GitHubIssuesSource("source/queue", ("alex",))
+    tracker = GitHubIssuesTracker(client, source, "target/repo")
     tasks = tracker.list_ready()
-    assert [task.external_id for task in tasks] == ["1"]
+    assert [task.source_issue.number for task in tasks] == [1]
+    assert tasks[0].source_issue.repository == "source/queue"
+    assert tasks[0].target_repository == "target/repo"
     first = tracker.claim(tasks[0])
     second = tracker.claim(tasks[0])
     assert first.claimed and first.task.state == TaskState.RUNNING
     assert not second.claimed
     assert client.labels == [(1, "factory:ready", "factory:running")]
+    assert set(client.issue_repositories) == {"source/queue"}
+
+    tracker.reconcile_pull_requests(first.task)
+    assert client.pull_request_repositories == ["target/repo"]
 
 
 def test_claim_returns_freshly_relisted_issue_body() -> None:
     client = FakeGhClient()
     tracker = GitHubIssuesTracker(
-        client, GitHubIssuesSource("me/dots", Path("/tmp/dots"), ("alex",))
+        client, GitHubIssuesSource("source/queue", ("alex",)), "target/repo"
     )
     selected = tracker.list_ready()[0]
     changed_body = VALID_BODY.replace("Mode: full", "Mode: focused")
@@ -103,7 +121,7 @@ def test_claim_returns_freshly_relisted_issue_body() -> None:
 def test_claim_fails_if_post_mutation_snapshot_is_no_longer_running() -> None:
     client = FakeGhClient()
     tracker = GitHubIssuesTracker(
-        client, GitHubIssuesSource("me/dots", Path("/tmp/dots"), ("alex",))
+        client, GitHubIssuesSource("source/queue", ("alex",)), "target/repo"
     )
     selected = tracker.list_ready()[0]
     client.get_issue = lambda repository, issue: replace(  # type: ignore[method-assign]
@@ -119,7 +137,7 @@ def test_claim_fails_if_post_mutation_snapshot_is_no_longer_running() -> None:
 def test_refresh_rejects_closed_issue() -> None:
     client = FakeGhClient()
     tracker = GitHubIssuesTracker(
-        client, GitHubIssuesSource("me/dots", Path("/tmp/dots"), ("alex",))
+        client, GitHubIssuesSource("source/queue", ("alex",)), "target/repo"
     )
     running = replace(tracker.list_ready()[0], state=TaskState.RUNNING)
     client.get_issue = lambda repository, issue: replace(  # type: ignore[method-assign]
@@ -144,7 +162,7 @@ def test_lists_and_atomically_claims_deferred_work() -> None:
         )
     ]
     tracker = GitHubIssuesTracker(
-        client, GitHubIssuesSource("me/dots", Path("/tmp/dots"), ("alex",))
+        client, GitHubIssuesSource("source/queue", ("alex",)), "target/repo"
     )
 
     task = tracker.list_deferred()[0]
@@ -160,7 +178,7 @@ def test_lists_and_atomically_claims_deferred_work() -> None:
 def test_admission_blocks_tracking_and_unresolved_dependencies() -> None:
     client = FakeGhClient()
     tracker = GitHubIssuesTracker(
-        client, GitHubIssuesSource("me/dots", Path("/tmp/dots"), ("alex",))
+        client, GitHubIssuesSource("source/queue", ("alex",)), "target/repo"
     )
     tracking = replace(
         tracker.list_ready()[0],
@@ -198,11 +216,11 @@ def test_transition_to_deferred_uses_configured_label_and_ai_authored_comment() 
     tracker = GitHubIssuesTracker(
         client,
         GitHubIssuesSource(
-            "me/dots",
-            Path("/tmp/dots"),
+            "source/queue",
             ("alex",),
             deferred_label="queue:later",
         ),
+        "target/repo",
     )
     running = tracker.claim(tracker.list_ready()[0]).task
 

--- a/tests/adapters/test_pi.py
+++ b/tests/adapters/test_pi.py
@@ -1,6 +1,7 @@
 import io
 import json
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -25,6 +26,7 @@ from groundskeeper.domain.automation import (
     AdmittedTask,
     AutomationTask,
     FailureDisposition,
+    GitHubIssueIdentity,
     WorkResult,
 )
 from groundskeeper.domain.config import AutomationPolicy, PiRunnerConfig
@@ -82,12 +84,12 @@ def test_pi_runner_renders_normalized_task_context_with_typed_settings() -> None
     client = FakePiClient()
     task = AutomationTask(
         "github",
-        "3",
         "Fix it",
         "Acceptance",
         "https://issue/3",
         "alex",
-        "me/dots",
+        GitHubIssueIdentity("source/queue", 3),
+        "target/repo",
         contract=_contract(),
     )
     result = _runner(client).run(_admitted(task))
@@ -97,7 +99,8 @@ def test_pi_runner_renders_normalized_task_context_with_typed_settings() -> None
     assert "TASK_TITLE: Fix it" in client.prompt
     assert "TASK_BODY:\nAcceptance" in client.prompt
     assert "TASK_URL: https://issue/3" in client.prompt
-    assert "REPOSITORY: me/dots" in client.prompt
+    assert "REPOSITORY: target/repo" in client.prompt
+    assert "FACTORY_CLOSING_REFERENCE: source/queue#3" in client.prompt
     assert "FACTORY_TASK_KIND: runnable" in client.prompt
     assert "FACTORY_EXECUTION_MODE: full" in client.prompt
     assert "FACTORY_DEPENDENCY_STATUS: resolved" in client.prompt
@@ -105,22 +108,46 @@ def test_pi_runner_renders_normalized_task_context_with_typed_settings() -> None
     assert client.cwd == Path("/repos/dots")
     assert client.settings is not None
     assert client.settings.session_id
-    assert client.settings.name == "gk-me-dots-3"
+    assert client.settings.name == "gk-source-queue-3-to-target-repo"
     assert client.settings.approval == "allow"
     assert client.settings.timeout_seconds == 7200
     assert "POLICY_OUTPUT: draft-pr" in client.prompt
     assert "POLICY_MERGE: never" in client.prompt
     assert f"FACTORY_SESSION_ID: {client.settings.session_id}" in client.prompt
-    assert "FACTORY_SESSION_NAME: gk-me-dots-3" in client.prompt
+    assert "FACTORY_SESSION_NAME: gk-source-queue-3-to-target-repo" in client.prompt
     assert (
         f"FACTORY_RESUME_COMMAND: pi --session {client.settings.session_id}"
         in client.prompt
     )
 
 
+def test_same_repository_task_renders_short_closing_reference() -> None:
+    client = FakePiClient()
+    task = AutomationTask(
+        "github",
+        "Fix it",
+        "Acceptance",
+        "https://issue/3",
+        "alex",
+        GitHubIssueIdentity("target/repo", 3),
+        "target/repo",
+        contract=_contract(),
+    )
+
+    _runner(client).run(_admitted(task))
+
+    assert "FACTORY_CLOSING_REFERENCE: #3" in client.prompt
+
+
 def test_admitted_task_rejects_mismatched_contract() -> None:
     task = AutomationTask(
-        "github", "3", "Fix it", "Acceptance", "https://issue/3", "alex", "me/dots"
+        "github",
+        "Fix it",
+        "Acceptance",
+        "https://issue/3",
+        "alex",
+        GitHubIssueIdentity("source/queue", 3),
+        "target/repo",
     )
 
     with pytest.raises(ValueError, match="requires its normalized contract"):
@@ -131,33 +158,79 @@ def test_pi_runner_exposes_session_metadata_without_starting_worker() -> None:
     client = FakePiClient()
     task = AutomationTask(
         "github",
-        "3",
         "Fix it",
         "Acceptance",
         "https://issue/3",
         "alex",
-        "me/dots",
+        GitHubIssueIdentity("source/queue", 3),
+        "target/repo",
         contract=_contract(),
     )
 
     metadata = _runner(client).session_metadata(task)
 
     assert metadata.session_id
-    assert metadata.session_name == "gk-me-dots-3"
+    assert metadata.session_name == "gk-source-queue-3-to-target-repo"
     assert metadata.resume_command == f"pi --session {metadata.session_id}"
     assert client.settings is None
+
+
+def test_deterministic_session_identity_resists_cross_source_collisions() -> None:
+    client = FakePiClient()
+    first = AutomationTask(
+        "github",
+        "Fix it",
+        "Acceptance",
+        "https://issue/3",
+        "alex",
+        GitHubIssueIdentity("first/queue", 3),
+        "target/repo",
+        contract=_contract(),
+    )
+    second_source = replace(first, source_issue=GitHubIssueIdentity("second/queue", 3))
+    second_target = replace(first, target_repository="other/target")
+    runner = _runner(client)
+
+    first_session = runner.session_metadata(first).session_id
+    assert first_session != runner.session_metadata(second_source).session_id
+    assert first_session != runner.session_metadata(second_target).session_id
+
+
+def test_deterministic_session_identity_is_case_insensitive() -> None:
+    client = FakePiClient()
+    task = AutomationTask(
+        "github",
+        "Fix it",
+        "Acceptance",
+        "https://issue/3",
+        "alex",
+        GitHubIssueIdentity("Source/Queue", 3),
+        "Target/Repo",
+        contract=_contract(),
+    )
+    differently_cased = replace(
+        task,
+        source_issue=GitHubIssueIdentity("source/queue", 3),
+        target_repository="target/repo",
+    )
+    runner = _runner(client)
+
+    assert (
+        runner.session_metadata(task).session_id
+        == runner.session_metadata(differently_cased).session_id
+    )
 
 
 def test_recovery_reuses_deterministic_session_and_changes_only_context() -> None:
     client = FakePiClient()
     task = AutomationTask(
         "github",
-        "3",
         "Fix it",
         "Acceptance",
         "https://issue/3",
         "alex",
-        "me/dots",
+        GitHubIssueIdentity("source/queue", 3),
+        "target/repo",
         contract=_contract(),
     )
     runner = _runner(client)

--- a/tests/adapters/test_target_checkout.py
+++ b/tests/adapters/test_target_checkout.py
@@ -27,7 +27,9 @@ class FakeProcess:
     [
         "https://github.com/Example/Widgets.git\n",
         "git@github.com:Example/Widgets.git\n",
+        "org-1965106@github.com:Example/Widgets.git\n",
         "ssh://git@github.com/Example/Widgets.git\n",
+        "ssh://org-1965106@github.com/Example/Widgets.git\n",
     ],
 )
 def test_matching_github_https_and_ssh_origins_are_accepted(origin: str) -> None:

--- a/tests/adapters/test_target_checkout.py
+++ b/tests/adapters/test_target_checkout.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+import pytest
+
+from groundskeeper.adapters.process import CommandResult
+from groundskeeper.adapters.target_checkout import (
+    TargetCheckoutError,
+    validate_target_checkout,
+)
+
+
+class FakeProcess:
+    def __init__(self, results: list[tuple[int, str, str]]) -> None:
+        self.results = results
+        self.calls: list[tuple[str, ...]] = []
+
+    def run(
+        self, argv: tuple[str, ...], cwd: Path, timeout: int | None = None
+    ) -> CommandResult:
+        self.calls.append(argv)
+        exit_code, stdout, stderr = self.results[len(self.calls) - 1]
+        return CommandResult(argv, cwd, exit_code, stdout, stderr)
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "https://github.com/Example/Widgets.git\n",
+        "git@github.com:Example/Widgets.git\n",
+        "ssh://git@github.com/Example/Widgets.git\n",
+    ],
+)
+def test_matching_github_https_and_ssh_origins_are_accepted(origin: str) -> None:
+    process = FakeProcess([(0, "true\n", ""), (0, origin, "")])
+
+    validate_target_checkout(process, Path("/repo"), "example/widgets")
+
+    assert process.calls == [
+        ("git", "rev-parse", "--is-inside-work-tree"),
+        ("git", "remote", "get-url", "origin"),
+    ]
+
+
+def test_non_git_target_checkout_is_rejected() -> None:
+    process = FakeProcess([(128, "", "not a git repository")])
+
+    with pytest.raises(TargetCheckoutError, match="not a Git worktree"):
+        validate_target_checkout(process, Path("/repo"), "example/widgets")
+
+
+def test_mismatched_target_checkout_is_rejected() -> None:
+    process = FakeProcess(
+        [(0, "true\n", ""), (0, "https://github.com/other/repo.git\n", "")]
+    )
+
+    with pytest.raises(TargetCheckoutError, match="does not match"):
+        validate_target_checkout(process, Path("/repo"), "example/widgets")
+
+
+@pytest.mark.parametrize(
+    "origin_result",
+    [
+        (2, "", "No such remote 'origin'"),
+        (0, "https://gitlab.com/example/widgets.git\n", ""),
+        (0, "git@github.com:example/too/many.git\n", ""),
+    ],
+)
+def test_missing_or_malformed_origin_is_rejected(
+    origin_result: tuple[int, str, str],
+) -> None:
+    process = FakeProcess([(0, "true\n", ""), origin_result])
+
+    with pytest.raises(TargetCheckoutError):
+        validate_target_checkout(process, Path("/repo"), "example/widgets")

--- a/tests/cli/test_cli_automation.py
+++ b/tests/cli/test_cli_automation.py
@@ -8,17 +8,33 @@ from click.testing import CliRunner
 
 from groundskeeper.adapters.tick_lock import TickAlreadyRunningError
 from groundskeeper.cli.main import _automation_lock_path, cli
-from groundskeeper.domain.automation import AutomationTask, TaskState, TickResult
+from groundskeeper.domain.automation import (
+    AutomationTask,
+    GitHubIssueIdentity,
+    TaskState,
+    TickResult,
+)
 from groundskeeper.domain.config import get_automations
+
+
+@pytest.fixture(autouse=True)
+def _accept_target_checkout(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "groundskeeper.cli.main.validate_target_checkout",
+        lambda process, repository_path, expected_repository: None,
+    )
+
 
 CONFIG = """
 automations:
   daily-dev:
     source:
       type: github-issues
+      repository: me/queue
+      trusted-authors: [alex]
+    target:
       repository: me/dots
       repository-path: /tmp
-      trusted-authors: [alex]
     runner:
       type: pi
       skill: codex-code-review
@@ -43,9 +59,46 @@ def test_automation_list_json(tmp_path: Path) -> None:
         result = runner.invoke(cli, ["automation", "list", "--json"])
     assert result.exit_code == 0
     payload = json.loads(result.output)
-    assert payload["version"] == 1
-    assert payload["status"] == "ok"
-    assert payload["data"]["automations"][0]["runner"]["skill"] == "codex-code-review"
+    assert payload == {
+        "version": 2,
+        "status": "ok",
+        "data": {
+            "automations": [
+                {
+                    "name": "daily-dev",
+                    "source": {
+                        "type": "github-issues",
+                        "repository": "me/queue",
+                        "trusted_authors": ["alex"],
+                        "labels": {
+                            "ready": "factory:ready",
+                            "running": "factory:running",
+                            "deferred": "factory:deferred",
+                            "review": "factory:review",
+                            "blocked": "factory:blocked",
+                        },
+                    },
+                    "target": {
+                        "repository": "me/dots",
+                        "repository_path": str(Path("/tmp").resolve()),
+                    },
+                    "runner": {
+                        "type": "pi",
+                        "skill": "codex-code-review",
+                        "approval": "allow",
+                        "session": "deterministic",
+                        "timeout_seconds": 7200,
+                    },
+                    "policy": {
+                        "concurrency": 1,
+                        "output": "draft-pr",
+                        "merge": "never",
+                    },
+                }
+            ]
+        },
+        "exit_code": 0,
+    }
 
 
 def test_repository_locks_are_host_scoped_and_identity_stable(
@@ -58,7 +111,7 @@ def test_repository_locks_are_host_scoped_and_identity_stable(
     queue_a, queue_b = get_automations(yaml.safe_load(config))
     other_repo = get_automations(
         yaml.safe_load(
-            CONFIG.replace("daily-dev:", "queue-c:").replace("me/dots", "me/other")
+            CONFIG.replace("daily-dev:", "queue-c:").replace("me/queue", "me/other")
         )
     )[0]
     assert _automation_lock_path(queue_a) == _automation_lock_path(queue_b)
@@ -80,27 +133,89 @@ def test_automation_show_and_validate_use_versioned_envelopes(
         show = runner.invoke(cli, ["automation", "show", "daily-dev", "--json"])
         validate = runner.invoke(cli, ["automation", "validate", "daily-dev", "--json"])
     assert show.exit_code == 0
-    shown = json.loads(show.output)["data"]["automation"]
-    assert shown["name"] == "daily-dev"
-    assert shown["repository_path"] == str(Path("/tmp").resolve())
-    assert shown["labels"]["deferred"] == "factory:deferred"
-    assert shown["labels"]["review"] == "factory:review"
-    assert shown["runner"]["timeout_seconds"] == 7200
-    assert shown["skill"] == {
-        "name": "codex-code-review",
-        "source_kind": "builtin",
-        "path": str(
-            Path(__file__).parents[2]
-            / "groundskeeper"
-            / "builtins"
-            / "skills"
-            / "codex-code-review"
-        ),
+    skill_path = str(
+        Path(__file__).parents[2]
+        / "groundskeeper"
+        / "builtins"
+        / "skills"
+        / "codex-code-review"
+    )
+    assert json.loads(show.output) == {
+        "version": 2,
+        "status": "ok",
+        "data": {
+            "automation": {
+                "name": "daily-dev",
+                "source": {
+                    "type": "github-issues",
+                    "repository": "me/queue",
+                    "trusted_authors": ["alex"],
+                    "labels": {
+                        "ready": "factory:ready",
+                        "running": "factory:running",
+                        "deferred": "factory:deferred",
+                        "review": "factory:review",
+                        "blocked": "factory:blocked",
+                    },
+                },
+                "target": {
+                    "repository": "me/dots",
+                    "repository_path": str(Path("/tmp").resolve()),
+                },
+                "runner": {
+                    "type": "pi",
+                    "skill": "codex-code-review",
+                    "approval": "allow",
+                    "session": "deterministic",
+                    "timeout_seconds": 7200,
+                },
+                "policy": {
+                    "concurrency": 1,
+                    "output": "draft-pr",
+                    "merge": "never",
+                },
+                "skill": {
+                    "name": "codex-code-review",
+                    "source_kind": "builtin",
+                    "path": skill_path,
+                },
+            }
+        },
+        "exit_code": 0,
     }
     assert validate.exit_code == 0
     validated = json.loads(validate.output)
-    assert validated["version"] == 1
+    assert validated["version"] == 2
     assert validated["data"]["automations"][0]["skill"]["name"] == "codex-code-review"
+
+
+@patch("groundskeeper.cli.main.GitHubIssuesTracker")
+def test_inspect_full_versioned_payload(mock_tracker: object, tmp_path: Path) -> None:
+    tracker = mock_tracker.return_value  # type: ignore[attr-defined]
+    tracker.list_running.return_value = []
+    tracker.list_deferred.return_value = []
+    tracker.list_ready.return_value = []
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path(".groundskeeper").mkdir(exist_ok=True)
+        Path(".groundskeeper/config.yml").write_text(CONFIG)
+        result = runner.invoke(cli, ["automation", "inspect", "daily-dev", "--json"])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "version": 2,
+        "status": "ok",
+        "data": {
+            "automation": "daily-dev",
+            "source": {"repository": "me/queue"},
+            "target": {
+                "repository": "me/dots",
+                "repository_path": str(Path("/tmp").resolve()),
+            },
+            "tasks": [],
+        },
+        "exit_code": 0,
+    }
 
 
 def test_automation_leaf_help_has_configured_examples() -> None:
@@ -130,11 +245,11 @@ def test_tick_dry_run_omits_issue_body_from_json(
 ) -> None:
     task = AutomationTask(
         "github",
-        "7",
         "Do work",
         "private acceptance criteria",
-        "https://github.com/me/dots/issues/7",
+        "https://github.com/me/queue/issues/7",
         "alex",
+        GitHubIssueIdentity("me/queue", 7),
         "me/dots",
     )
     mock_tick.return_value = TickResult("daily-dev", "would-dispatch", task)  # type: ignore[attr-defined]
@@ -147,7 +262,32 @@ def test_tick_dry_run_omits_issue_body_from_json(
         )
     assert result.exit_code == 0
     assert "private acceptance criteria" not in result.output
-    assert json.loads(result.output)["data"]["task"]["id"] == "7"
+    assert json.loads(result.output) == {
+        "version": 2,
+        "status": "would-dispatch",
+        "data": {
+            "automation": "daily-dev",
+            "source": {"repository": "me/queue"},
+            "target": {
+                "repository": "me/dots",
+                "repository_path": str(Path("/tmp").resolve()),
+            },
+            "task": {
+                "id": "7",
+                "title": "Do work",
+                "url": "https://github.com/me/queue/issues/7",
+                "source": {"repository": "me/queue", "issue": 7},
+                "target": {"repository": "me/dots"},
+                "state": "ready",
+            },
+            "pull_request_url": None,
+            "detail": "",
+            "session_id": None,
+            "session_name": None,
+            "resume_command": None,
+        },
+        "exit_code": 0,
+    }
 
 
 @patch("groundskeeper.cli.main.PiClient.supports_automation", return_value=False)
@@ -220,7 +360,7 @@ def test_tick_unknown_name_json_envelope(tmp_path: Path) -> None:
     payload = json.loads(result.output)
     assert result.exit_code == 2
     assert payload["status"] == "error" and payload["exit_code"] == 2
-    assert payload["version"] == 1
+    assert payload["version"] == 2
 
 
 @pytest.mark.parametrize(
@@ -275,11 +415,11 @@ def test_deferred_result_is_structured_and_nonfatal(
 ) -> None:
     task = AutomationTask(
         "github",
-        "7",
         "Do work",
         "body",
-        "https://github.com/me/dots/issues/7",
+        "https://github.com/me/queue/issues/7",
         "alex",
+        GitHubIssueIdentity("me/queue", 7),
         "me/dots",
         TaskState.DEFERRED,
     )

--- a/tests/domain/test_automation_config.py
+++ b/tests/domain/test_automation_config.py
@@ -6,75 +6,19 @@ from groundskeeper.domain.config import get_automations
 from groundskeeper.domain.errors import ConfigError
 
 
-def test_parses_github_pi_automation() -> None:
-    items = get_automations(
-        {
-            "automations": {
-                "daily": {
-                    "source": {
-                        "type": "github-issues",
-                        "repository": "me/dots",
-                        "repository-path": "/tmp/dots",
-                        "trusted-authors": ["me"],
-                    },
-                    "runner": {
-                        "type": "pi",
-                        "skill": "issue-implementation",
-                        "approval": "allow",
-                        "session": "deterministic",
-                    },
-                    "policy": {
-                        "concurrency": 1,
-                        "output": "draft-pr",
-                        "merge": "never",
-                    },
-                }
-            }
-        }
-    )
-    assert items[0].source.repository_path == Path("/tmp/dots").resolve()
-    assert items[0].source.trusted_authors == ("me",)
-    assert items[0].source.deferred_label == "factory:deferred"
-    assert items[0].runner.skill == "issue-implementation"
-    assert items[0].runner.approval == "allow"
-    assert items[0].runner.session == "deterministic"
-    assert items[0].runner.timeout_seconds == 7200
-
-
-def test_rejects_non_positive_pi_timeout() -> None:
-    config = {
-        "automations": {
-            "daily": {
-                "source": {
-                    "type": "github-issues",
-                    "repository": "me/dots",
-                    "repository-path": "/tmp/dots",
-                    "trusted-authors": ["me"],
-                },
-                "runner": {
-                    "type": "pi",
-                    "skill": "issue-implementation",
-                    "approval": "allow",
-                    "session": "deterministic",
-                    "timeout-seconds": 0,
-                },
-            }
-        }
-    }
-    with pytest.raises(ConfigError, match=r"runner\.timeout-seconds"):
-        get_automations(config)
-
-
 def _valid_automation_config() -> dict[str, object]:
     return {
         "automations": {
             "daily": {
                 "source": {
                     "type": "github-issues",
-                    "repository": "me/dots",
-                    "repository-path": "/tmp/dots",
+                    "repository": "me/queue",
                     "trusted-authors": ["me"],
                     "labels": {},
+                },
+                "target": {
+                    "repository": "me/dots",
+                    "repository-path": "/tmp/dots",
                 },
                 "runner": {
                     "type": "pi",
@@ -88,11 +32,82 @@ def _valid_automation_config() -> dict[str, object]:
     }
 
 
+def test_parses_explicit_source_and_target_automation() -> None:
+    item = get_automations(_valid_automation_config())[0]
+
+    assert item.source.repository == "me/queue"
+    assert item.source.trusted_authors == ("me",)
+    assert item.source.deferred_label == "factory:deferred"
+    assert item.target.repository == "me/dots"
+    assert item.target.repository_path == Path("/tmp/dots").resolve()
+    assert item.runner.skill == "issue-implementation"
+    assert item.runner.approval == "allow"
+    assert item.runner.session == "deterministic"
+    assert item.runner.timeout_seconds == 7200
+
+
+@pytest.mark.parametrize("missing", ["source", "target"])
+def test_requires_explicit_source_and_target(missing: str) -> None:
+    config = _valid_automation_config()
+    del config["automations"]["daily"][missing]  # type: ignore[index]
+
+    with pytest.raises(ConfigError, match=missing):
+        get_automations(config)
+
+
+def test_rejects_legacy_source_repository_path_as_unknown() -> None:
+    config = _valid_automation_config()
+    config["automations"]["daily"]["source"]["repository-path"] = "/tmp/queue"  # type: ignore[index]
+
+    with pytest.raises(ConfigError, match=r"source.*unknown key 'repository-path'"):
+        get_automations(config)
+
+
+@pytest.mark.parametrize("key", ["repository", "repository-path"])
+def test_requires_every_target_key(key: str) -> None:
+    config = _valid_automation_config()
+    del config["automations"]["daily"]["target"][key]  # type: ignore[index]
+
+    with pytest.raises(ConfigError, match=rf"target\.{key}"):
+        get_automations(config)
+
+
+def test_rejects_relative_target_repository_path() -> None:
+    config = _valid_automation_config()
+    config["automations"]["daily"]["target"]["repository-path"] = "../dots"  # type: ignore[index]
+
+    with pytest.raises(ConfigError, match=r"target\.repository-path must be absolute"):
+        get_automations(config)
+
+
+@pytest.mark.parametrize("section", ["source", "target"])
+@pytest.mark.parametrize(
+    "repository",
+    [" owner/repo", "owner/repo ", "owner /repo", "owner/", "/repo", "a/b/c"],
+)
+def test_rejects_noncanonical_repository_identity(
+    section: str, repository: str
+) -> None:
+    config = _valid_automation_config()
+    config["automations"]["daily"][section]["repository"] = repository  # type: ignore[index]
+
+    with pytest.raises(ConfigError, match=rf"{section}\.repository.*owner/repo"):
+        get_automations(config)
+
+
+def test_rejects_non_positive_pi_timeout() -> None:
+    config = _valid_automation_config()
+    config["automations"]["daily"]["runner"]["timeout-seconds"] = 0  # type: ignore[index]
+    with pytest.raises(ConfigError, match=r"runner\.timeout-seconds"):
+        get_automations(config)
+
+
 @pytest.mark.parametrize(
     ("section", "key", "expected"),
     [
         ("entry", "unexpected", "automations.daily"),
         ("source", "repo", "automations.daily.source"),
+        ("target", "checkout", "automations.daily.target"),
         ("runner", "timeout_seconds", "automations.daily.runner"),
         ("policy", "concurency", "automations.daily.policy"),
         ("labels", "done", "automations.daily.source.labels"),
@@ -107,7 +122,7 @@ def test_rejects_unknown_automation_keys(section: str, key: str, expected: str) 
         target = automation if section == "entry" else automation[section]  # type: ignore[index]
     target[key] = "invalid"  # type: ignore[index]
     with pytest.raises(ConfigError, match=expected):
-        get_automations(config)  # type: ignore[arg-type]
+        get_automations(config)
 
 
 def test_rejects_misspelled_top_level_automation() -> None:
@@ -148,71 +163,19 @@ def test_rejects_every_unknown_top_level_key(key: str) -> None:
 def test_rejects_incomplete_or_unsafe_pi_runner(
     runner: dict[str, str], message: str
 ) -> None:
+    config = _valid_automation_config()
+    config["automations"]["daily"]["runner"] = runner  # type: ignore[index]
     with pytest.raises(ConfigError, match=message):
-        get_automations(
-            {
-                "automations": {
-                    "daily": {
-                        "source": {
-                            "type": "github-issues",
-                            "repository": "me/dots",
-                            "repository-path": "/tmp/dots",
-                            "trusted-authors": ["me"],
-                        },
-                        "runner": runner,
-                    }
-                }
-            }
-        )
+        get_automations(config)
 
 
 @pytest.mark.parametrize("name", ["/tmp/lock", "../escape", "queue/a", "UPPER"])
 def test_rejects_unsafe_automation_names(name: str) -> None:
+    config = _valid_automation_config()
+    value = config["automations"].pop("daily")  # type: ignore[union-attr]
+    config["automations"][name] = value  # type: ignore[index]
     with pytest.raises(ConfigError, match="kebab-case"):
-        get_automations(
-            {
-                "automations": {
-                    name: {
-                        "source": {
-                            "type": "github-issues",
-                            "repository": "me/dots",
-                            "repository-path": "/tmp/dots",
-                            "trusted-authors": ["me"],
-                        },
-                        "runner": {
-                            "type": "pi",
-                            "skill": "issue-implementation",
-                            "approval": "allow",
-                            "session": "deterministic",
-                        },
-                    }
-                }
-            }
-        )
-
-
-def test_rejects_relative_repository_path() -> None:
-    with pytest.raises(ConfigError, match="must be absolute"):
-        get_automations(
-            {
-                "automations": {
-                    "daily": {
-                        "source": {
-                            "type": "github-issues",
-                            "repository": "me/dots",
-                            "repository-path": "../dots",
-                            "trusted-authors": ["me"],
-                        },
-                        "runner": {
-                            "type": "pi",
-                            "skill": "issue-implementation",
-                            "approval": "allow",
-                            "session": "deterministic",
-                        },
-                    }
-                }
-            }
-        )
+        get_automations(config)
 
 
 @pytest.mark.parametrize(
@@ -226,28 +189,10 @@ def test_rejects_relative_repository_path() -> None:
     ],
 )
 def test_rejects_invalid_lifecycle_labels(labels: dict[str, object]) -> None:
+    config = _valid_automation_config()
+    config["automations"]["daily"]["source"]["labels"] = labels  # type: ignore[index]
     with pytest.raises(ConfigError, match=r"source\.labels"):
-        get_automations(
-            {
-                "automations": {
-                    "daily": {
-                        "source": {
-                            "type": "github-issues",
-                            "repository": "me/dots",
-                            "repository-path": "/tmp/dots",
-                            "trusted-authors": ["me"],
-                            "labels": labels,
-                        },
-                        "runner": {
-                            "type": "pi",
-                            "skill": "issue-implementation",
-                            "approval": "allow",
-                            "session": "deterministic",
-                        },
-                    }
-                }
-            }
-        )
+        get_automations(config)
 
 
 def test_parses_custom_deferred_label() -> None:
@@ -270,25 +215,7 @@ def test_parses_custom_deferred_label() -> None:
     ],
 )
 def test_rejects_unsafe_policy(policy: dict[str, object]) -> None:
+    config = _valid_automation_config()
+    config["automations"]["daily"]["policy"] = policy  # type: ignore[index]
     with pytest.raises(ConfigError):
-        get_automations(
-            {
-                "automations": {
-                    "daily": {
-                        "source": {
-                            "type": "github-issues",
-                            "repository": "me/dots",
-                            "repository-path": "/tmp/dots",
-                            "trusted-authors": ["me"],
-                        },
-                        "runner": {
-                            "type": "pi",
-                            "skill": "issue-implementation",
-                            "approval": "allow",
-                            "session": "deterministic",
-                        },
-                        "policy": policy,
-                    }
-                }
-            }
-        )
+        get_automations(config)

--- a/tests/e2e/test_e2e_commands.py
+++ b/tests/e2e/test_e2e_commands.py
@@ -324,14 +324,21 @@ class TestAutomationE2E:
         assert validated_automation["target"]["repository"] == "target/repo"
         assert json.loads(validated.stdout)["version"] == 2
 
-    def test_dry_run_is_compact_and_does_not_launch_pi(self, tmp_path: Path) -> None:
+    def test_dry_run_is_compact_and_does_not_launch_pi_or_write_state(
+        self, tmp_path: Path
+    ) -> None:
         repo, env = _factory_flow_repo(tmp_path, "ready")
+        state_home = tmp_path / "state"
+        env["GROUNDSKEEPER_STATE_HOME"] = str(state_home)
+
         result = run_gk(
             "automation", "tick", "daily", "--dry-run", "--json", cwd=repo, env=env
         )
+
         assert result.returncode == 0
         assert json.loads(result.stdout)["status"] == "would-dispatch"
         assert "Factory Task" not in result.stdout
+        assert not state_home.exists()
 
     def test_inspect_reports_typed_admission_without_mutation(
         self, tmp_path: Path

--- a/tests/e2e/test_e2e_commands.py
+++ b/tests/e2e/test_e2e_commands.py
@@ -14,13 +14,44 @@ from .conftest import requires_claude, requires_gk
 FACTORY_TASK_BODY = "## Factory Task\n\nSchema: 1\nKind: runnable\nMode: full\n\n## Dependencies\n\nNone"
 
 
+def _pull_request_graphql(*, draft: bool = True, include: bool = True) -> str:
+    nodes: list[dict[str, object]] = []
+    if include:
+        nodes.append(
+            {
+                "url": "https://github.com/target/repo/pull/9",
+                "isDraft": draft,
+                "state": "OPEN",
+                "repository": {"nameWithOwner": "target/repo"},
+            }
+        )
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "closedByPullRequestsReferences": {
+                            "nodes": nodes,
+                            "pageInfo": {
+                                "hasNextPage": False,
+                                "endCursor": None,
+                            },
+                        }
+                    }
+                }
+            }
+        },
+        separators=(",", ":"),
+    )
+
+
 def _issue_object_json(state: str, body: str = FACTORY_TASK_BODY) -> str:
     return json.dumps(
         {
             "number": 7,
             "title": "Do work",
             "body": body,
-            "url": "https://github.com/me/repo/issues/7",
+            "url": "https://github.com/source/queue/issues/7",
             "author": {"login": "alex"},
             "labels": [{"name": f"factory:{state}"}],
             "state": "open",
@@ -39,14 +70,26 @@ def _factory_repo(tmp_path: Path, gh_output: str) -> tuple[Path, dict[str, str]]
     (repo / ".groundskeeper/skills/issue-implementation/SKILL.md").write_text(
         "---\nname: issue-implementation\ndescription: Implement one issue\n---\n\nImplement it."
     )
+    subprocess.run(
+        ["git", "init", "-q"], cwd=repo, check=True, capture_output=True, text=True
+    )
+    subprocess.run(
+        ["git", "remote", "add", "origin", "git@github.com:target/repo.git"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
     (repo / ".groundskeeper/config.yml").write_text(
         f"""automations:
   daily:
     source:
       type: github-issues
-      repository: me/repo
-      repository-path: {repo}
+      repository: source/queue
       trusted-authors: [alex]
+    target:
+      repository: target/repo
+      repository-path: {repo}
     runner:
       type: pi
       skill: issue-implementation
@@ -76,17 +119,17 @@ def _factory_flow_repo(
     pr_created = tmp_path / "pr-created"
     issue = _issue_json(state)
     issue_view = _issue_object_json("running")
-    draft_json = "true" if draft else "false"
+    pull_requests = _pull_request_graphql(draft=draft)
+    no_pull_requests = _pull_request_graphql(include=False)
     (binary_dir / "gh").write_text(
         "#!/bin/sh\n"
         'case "$*" in\n'
         f"  *\"issue view\"*) printf '%s' '{issue_view}' ;;\n"
         f"  *\"issue list\"*\"factory:{state}\"*) printf '%s' '{issue}' ;;\n"
         "  *\"issue list\"*) printf '%s' '[]' ;;\n"
-        f"  *\"pr list\"*) if [ -f '{pr_created}' ]; then "
-        'printf \'%s\' \'[{"url":"https://github.com/me/repo/pull/9",'
-        f'"isDraft":{draft_json},"closingIssuesReferences":[{{"number":7}}]}}]\'; '
-        "else printf '%s' '[]'; fi ;;\n"
+        f"  *\"api graphql\"*) if [ -f '{pr_created}' ]; then "
+        f"printf '%s' '{pull_requests}'; "
+        f"else printf '%s' '{no_pull_requests}'; fi ;;\n"
         "  *) printf '%s' '' ;;\n"
         "esac\n"
     )
@@ -94,7 +137,7 @@ def _factory_flow_repo(
     pi.write_text(
         "#!/bin/sh\n"
         + (
-            f"touch '{pr_created}'\nprintf '%s' 'https://github.com/me/repo/pull/9'\n"
+            f"touch '{pr_created}'\nprintf '%s' 'https://github.com/target/repo/pull/9'\n"
             if pi_success
             else "echo 'worker failed' >&2\nexit 1\n"
         )
@@ -111,6 +154,7 @@ def _public_blocker_factory_repo(
     gh_log = tmp_path / "public-blocker-gh.log"
     issue = _issue_json("ready")
     issue_view = _issue_object_json("running")
+    no_pull_requests = _pull_request_graphql(include=False)
     (binary_dir / "gh").write_text(
         "#!/bin/sh\n"
         f"LOG='{gh_log}'\n"
@@ -118,7 +162,7 @@ def _public_blocker_factory_repo(
         f"  *\"issue view\"*) printf '%s' '{issue_view}' ;;\n"
         f"  *\"issue list\"*\"factory:ready\"*) printf '%s' '{issue}' ;;\n"
         "  *\"issue list\"*) printf '%s' '[]' ;;\n"
-        "  *\"pr list\"*) printf '%s' '[]' ;;\n"
+        f"  *\"api graphql\"*) printf '%s' '{no_pull_requests}' ;;\n"
         '  *"issue comment"*) printf \'%s\' "$*" >> "$LOG" ;;\n'
         "  *) printf '%s' '' ;;\n"
         "esac\n"
@@ -152,13 +196,15 @@ def _deferred_factory_repo(tmp_path: Path) -> tuple[Path, dict[str, str], Path, 
     attempts.write_text("0")
     pr_created = tmp_path / "pr-created"
     issue_view = _issue_object_json("running")
+    pull_requests = _pull_request_graphql()
+    no_pull_requests = _pull_request_graphql(include=False)
     issue_prefix = json.dumps(
         [
             {
                 "number": 7,
                 "title": "Do work",
                 "body": FACTORY_TASK_BODY,
-                "url": "https://github.com/me/repo/issues/7",
+                "url": "https://github.com/source/queue/issues/7",
                 "author": {"login": "alex"},
                 "state": "open",
                 "labels": [{"name": "factory:"}],
@@ -184,10 +230,9 @@ def _deferred_factory_repo(tmp_path: Path) -> tuple[Path, dict[str, str], Path, 
         '  *"issue edit"*"factory:running"*"factory:review"*) '
         'echo \'running->review\' >> "$LOG"; echo review > "$STATE" ;;\n'
         '  *"issue comment"*) echo \'comment\' >> "$LOG" ;;\n'
-        f"  *\"pr list\"*) if [ -f '{pr_created}' ]; then "
-        'printf \'%s\' \'[{"url":"https://github.com/me/repo/pull/9",'
-        '"isDraft":true,"closingIssuesReferences":[{"number":7}]}]\'; '
-        "else printf '%s' '[]'; fi ;;\n"
+        f"  *\"api graphql\"*) if [ -f '{pr_created}' ]; then "
+        f"printf '%s' '{pull_requests}'; "
+        f"else printf '%s' '{no_pull_requests}'; fi ;;\n"
         "esac\n"
     )
     pi = binary_dir / "pi"
@@ -197,7 +242,7 @@ def _deferred_factory_repo(tmp_path: Path) -> tuple[Path, dict[str, str], Path, 
         f"COUNT=$(cat '{attempts}')\nCOUNT=$((COUNT + 1))\necho $COUNT > '{attempts}'\n"
         f"if [ \"$COUNT\" -lt 3 ]; then echo 'Codex usage limit reached; retry later' >&2; exit 1; fi\n"
         f"touch '{pr_created}'\n"
-        "printf '%s' 'https://github.com/me/repo/pull/9'\n"
+        "printf '%s' 'https://github.com/target/repo/pull/9'\n"
     )
     pi.chmod(0o755)
     return repo, env, gh_log, pi_log
@@ -213,13 +258,15 @@ def _stateful_factory_repo(tmp_path: Path) -> tuple[Path, dict[str, str], Path, 
     started = tmp_path / "pi-started"
     pr_created = tmp_path / "pr-created"
     issue_view = _issue_object_json("running")
+    pull_requests = _pull_request_graphql()
+    no_pull_requests = _pull_request_graphql(include=False)
     issue_prefix = json.dumps(
         [
             {
                 "number": 7,
                 "title": "Do work",
                 "body": FACTORY_TASK_BODY,
-                "url": "https://github.com/me/repo/issues/7",
+                "url": "https://github.com/source/queue/issues/7",
                 "author": {"login": "alex"},
                 "state": "open",
                 "labels": [{"name": "factory:"}],
@@ -240,10 +287,9 @@ def _stateful_factory_repo(tmp_path: Path) -> tuple[Path, dict[str, str], Path, 
         '  *"issue edit"*"factory:running"*"factory:review"*) '
         'echo \'running->review\' >> "$LOG"; echo review > "$STATE" ;;\n'
         '  *"issue comment"*) echo \'comment\' >> "$LOG" ;;\n'
-        f"  *\"pr list\"*) if [ -f '{pr_created}' ]; then "
-        'printf \'%s\' \'[{"url":"https://github.com/me/repo/pull/9",'
-        '"isDraft":true,"closingIssuesReferences":[{"number":7}]}]\'; '
-        "else printf '%s' '[]'; fi ;;\n"
+        f"  *\"api graphql\"*) if [ -f '{pr_created}' ]; then "
+        f"printf '%s' '{pull_requests}'; "
+        f"else printf '%s' '{no_pull_requests}'; fi ;;\n"
         "esac\n"
     )
     pi = binary_dir / "pi"
@@ -252,7 +298,7 @@ def _stateful_factory_repo(tmp_path: Path) -> tuple[Path, dict[str, str], Path, 
         f"echo \"$*\" >> '{pi_log}'\n"
         f"if [ ! -f '{started}' ]; then touch '{started}'; kill -9 $PPID; exit 137; fi\n"
         f"touch '{pr_created}'\n"
-        "printf '%s' 'https://github.com/me/repo/pull/9'\n"
+        "printf '%s' 'https://github.com/target/repo/pull/9'\n"
     )
     pi.chmod(0o755)
     return repo, env, gh_log, pi_log
@@ -269,11 +315,14 @@ class TestAutomationE2E:
         )
         assert listed.returncode == shown.returncode == validated.returncode == 0
         assert json.loads(listed.stdout)["data"]["automations"][0]["name"] == "daily"
-        assert (
-            json.loads(shown.stdout)["data"]["automation"]["runner"]["skill"]
-            == "issue-implementation"
-        )
-        assert json.loads(validated.stdout)["version"] == 1
+        shown_automation = json.loads(shown.stdout)["data"]["automation"]
+        assert shown_automation["runner"]["skill"] == "issue-implementation"
+        assert shown_automation["source"]["repository"] == "source/queue"
+        assert shown_automation["target"]["repository"] == "target/repo"
+        validated_automation = json.loads(validated.stdout)["data"]["automations"][0]
+        assert validated_automation["source"]["repository"] == "source/queue"
+        assert validated_automation["target"]["repository"] == "target/repo"
+        assert json.loads(validated.stdout)["version"] == 2
 
     def test_dry_run_is_compact_and_does_not_launch_pi(self, tmp_path: Path) -> None:
         repo, env = _factory_flow_repo(tmp_path, "ready")
@@ -307,7 +356,12 @@ class TestAutomationE2E:
         result = run_gk("automation", "inspect", "daily", "--json", cwd=repo, env=env)
 
         assert result.returncode == 0
-        task = json.loads(result.stdout)["data"]["tasks"][0]
+        data = json.loads(result.stdout)["data"]
+        task = data["tasks"][0]
+        assert data["source"]["repository"] == "source/queue"
+        assert data["target"]["repository"] == "target/repo"
+        assert task["source"] == {"repository": "source/queue", "issue": 7}
+        assert task["target"] == {"repository": "target/repo"}
         assert task["admitted"] is True
         assert task["kind"] == "runnable"
         assert task["mode"] == "full"
@@ -330,7 +384,7 @@ class TestAutomationE2E:
                     "number": 7,
                     "title": "Bad contract",
                     "body": bad_body,
-                    "url": "https://github.com/me/repo/issues/7",
+                    "url": "https://github.com/source/queue/issues/7",
                     "author": {"login": "alex"},
                     "labels": [{"name": "factory:ready"}],
                     "state": "open",
@@ -338,6 +392,7 @@ class TestAutomationE2E:
             ]
         )
         issue_view = _issue_object_json("running", bad_body)
+        no_pull_requests = _pull_request_graphql(include=False)
         (binary_dir / "gh").write_text(
             "#!/bin/sh\n"
             'case "$*" in\n'
@@ -345,7 +400,7 @@ class TestAutomationE2E:
             f"  *\"issue list\"*\"factory:ready\"*) printf '%s' '{issue}' ;;\n"
             "  *\"issue list\"*) printf '%s' '[]' ;;\n"
             '  *"issue edit"*|*"issue comment"*) : ;;\n'
-            "  *\"pr list\"*) printf '%s' '[]' ;;\n"
+            f"  *\"api graphql\"*) printf '%s' '{no_pull_requests}' ;;\n"
             "esac\n"
         )
         pi = binary_dir / "pi"
@@ -364,7 +419,7 @@ class TestAutomationE2E:
         assert result.returncode == 0
         payload = json.loads(result.stdout)
         assert payload["status"] == "no-work"
-        assert payload["version"] == 1
+        assert payload["version"] == 2
 
     def test_malformed_gh_json_is_structured_error(self, tmp_path: Path) -> None:
         repo, env = _factory_repo(tmp_path, "not-json")
@@ -380,8 +435,11 @@ class TestAutomationE2E:
         payload = json.loads(result.stdout)
         assert payload["status"] == "review"
         assert (
-            payload["data"]["pull_request_url"] == "https://github.com/me/repo/pull/9"
+            payload["data"]["pull_request_url"]
+            == "https://github.com/target/repo/pull/9"
         )
+        assert payload["data"]["source"]["repository"] == "source/queue"
+        assert payload["data"]["target"]["repository"] == "target/repo"
 
     def test_non_draft_closing_pr_is_blocked_as_policy_violation(
         self, tmp_path: Path

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -11,21 +11,35 @@ from groundskeeper.domain.automation import (
     AutomationTask,
     ClaimResult,
     FailureDisposition,
+    GitHubIssueIdentity,
+    PullRequestReconciliation,
     SessionMetadata,
     TaskState,
     WorkResult,
 )
-from groundskeeper.domain.config import Automation, GitHubIssuesSource, PiRunnerConfig
+from groundskeeper.domain.config import (
+    Automation,
+    AutomationTarget,
+    GitHubIssuesSource,
+    PiRunnerConfig,
+)
 from groundskeeper.domain.task_contract import parse_factory_task
 
 TASK_BODY = "## Factory Task\n\nSchema: 1\nKind: runnable\nMode: full\n\n## Dependencies\n\nNone\n"
 TASK_CONTRACT = parse_factory_task(TASK_BODY)
 TASK = AutomationTask(
-    "fake", "7", "Do work", TASK_BODY, "https://task/7", "alex", "me/dots"
+    "fake",
+    "Do work",
+    TASK_BODY,
+    "https://task/7",
+    "alex",
+    GitHubIssueIdentity("source/queue", 7),
+    "target/repo",
 )
 AUTOMATION = Automation(
     "daily",
-    GitHubIssuesSource("me/dots", Path("/tmp/dots"), ("alex",)),
+    GitHubIssuesSource("source/queue", ("alex",)),
+    AutomationTarget("target/repo", Path("/tmp/repo")),
     PiRunnerConfig(skill="issue-implementation"),
 )
 
@@ -38,6 +52,7 @@ class FakeTracker:
         self.transitions: list[tuple[TaskState, str]] = []
         self.pr: str | None = None
         self.policy_violation: str | None = None
+        self.reconciliation_error: str | None = None
 
     def list_ready(self) -> list[AutomationTask]:
         return self.tasks
@@ -69,15 +84,12 @@ class FakeTracker:
     ) -> None:
         self.transitions.append((state, detail))
 
-    def find_pull_request(self, task: AutomationTask) -> str | None:
-        return self.pr
-
-    def find_policy_violation(self, task: AutomationTask) -> str | None:
-        return self.policy_violation
-
-
-def _raise_github_timeout(task: AutomationTask) -> str | None:
-    raise RuntimeError("command timed out after 30 seconds: gh")
+    def reconcile_pull_requests(
+        self, task: AutomationTask
+    ) -> PullRequestReconciliation:
+        if self.reconciliation_error is not None:
+            raise RuntimeError(self.reconciliation_error)
+        return PullRequestReconciliation(self.pr, self.policy_violation)
 
 
 def _raise_running_label_changed(task: AutomationTask) -> AutomationTask:
@@ -251,8 +263,14 @@ def test_success_requires_pr_and_transitions_to_review() -> None:
 
 def test_successful_review_propagates_resumable_session_metadata() -> None:
     tracker = FakeTracker()
-    pull_requests = iter([None, "https://github/pr/1"])
-    tracker.find_pull_request = lambda task: next(pull_requests)  # type: ignore[method-assign]
+    pull_requests = iter(
+        [
+            PullRequestReconciliation(),
+            PullRequestReconciliation(),
+            PullRequestReconciliation("https://github/pr/1"),
+        ]
+    )
+    tracker.reconcile_pull_requests = lambda task: next(pull_requests)  # type: ignore[method-assign]
     worker = WorkResult(
         True,
         session_id="session-123",
@@ -352,14 +370,62 @@ def test_noncompliant_closing_pr_is_blocked_as_policy_violation() -> None:
     ]
 
 
-def test_post_worker_github_timeout_blocks_claimed_task() -> None:
+@pytest.mark.parametrize(
+    "state", [TaskState.READY, TaskState.RUNNING, TaskState.DEFERRED]
+)
+def test_preexisting_policy_violation_blocks_without_dispatch(state: TaskState) -> None:
     tracker = FakeTracker()
-    tracker.find_pull_request = _raise_github_timeout  # type: ignore[method-assign]
-    result = AutomationService(tracker, FakeRunner(WorkResult(True))).tick(AUTOMATION)
+    task = replace(TASK, state=state)
+    tracker.tasks = [task] if state is TaskState.READY else []
+    tracker.deferred_tasks = [task] if state is TaskState.DEFERRED else []
+    if state is TaskState.RUNNING:
+        tracker.list_running = lambda: [task]  # type: ignore[method-assign]
+    tracker.policy_violation = "Closing pull request is not open"
+    runner = FakeRunner(WorkResult(True))
+
+    result = AutomationService(tracker, runner).tick(AUTOMATION)
+
     assert result.status == "blocked"
+    assert runner.calls == 0
+    assert tracker.claims == []
     assert tracker.transitions == [
-        (TaskState.BLOCKED, "command timed out after 30 seconds: gh")
+        (TaskState.BLOCKED, "Closing pull request is not open")
     ]
+
+
+def test_accepted_open_draft_wins_when_violating_pr_also_exists() -> None:
+    tracker = FakeTracker()
+    tracker.pr = "https://github/pr/accepted"
+    tracker.policy_violation = "Closing pull request is not a draft"
+    runner = FakeRunner(WorkResult(True))
+
+    result = AutomationService(tracker, runner).tick(AUTOMATION)
+
+    assert result.status == "review"
+    assert result.pull_request_url == "https://github/pr/accepted"
+    assert runner.calls == 0
+    assert tracker.transitions == [(TaskState.REVIEW, "https://github/pr/accepted")]
+
+
+@pytest.mark.parametrize(
+    "detail",
+    [
+        "command timed out after 30 seconds: gh",
+        "closing pull request query exceeded the supported page limit",
+    ],
+)
+def test_indeterminate_reconciliation_does_not_dispatch_or_transition(
+    detail: str,
+) -> None:
+    tracker = FakeTracker()
+    tracker.reconciliation_error = detail
+    runner = FakeRunner(WorkResult(True))
+
+    with pytest.raises(RuntimeError, match=detail):
+        AutomationService(tracker, runner).tick(AUTOMATION)
+
+    assert runner.calls == 0
+    assert tracker.transitions == []
 
 
 def test_timed_out_worker_is_blocked_with_actionable_detail() -> None:
@@ -435,8 +501,14 @@ def test_deferred_task_is_claimed_before_ready_and_resumed_on_next_tick() -> Non
     tracker = FakeTracker()
     deferred = replace(TASK, state=TaskState.DEFERRED)
     tracker.deferred_tasks = [deferred]
-    pull_requests = iter([None, "https://github/pr/9"])
-    tracker.find_pull_request = lambda task: next(pull_requests)  # type: ignore[method-assign]
+    pull_requests = iter(
+        [
+            PullRequestReconciliation(),
+            PullRequestReconciliation(),
+            PullRequestReconciliation("https://github/pr/9"),
+        ]
+    )
+    tracker.reconcile_pull_requests = lambda task: next(pull_requests)  # type: ignore[method-assign]
     worker = WorkResult(
         True,
         session_id="session-123",
@@ -478,8 +550,16 @@ def test_repeat_transient_failure_returns_deferred_task_to_deferred() -> None:
 
 def test_running_work_has_priority_over_deferred_and_ready() -> None:
     tracker = FakeTracker()
-    running = replace(TASK, external_id="running", state=TaskState.RUNNING)
-    deferred = replace(TASK, external_id="deferred", state=TaskState.DEFERRED)
+    running = replace(
+        TASK,
+        source_issue=GitHubIssueIdentity("source/queue", 8),
+        state=TaskState.RUNNING,
+    )
+    deferred = replace(
+        TASK,
+        source_issue=GitHubIssueIdentity("source/queue", 9),
+        state=TaskState.DEFERRED,
+    )
     tracker.list_running = lambda: [running]  # type: ignore[method-assign]
     tracker.deferred_tasks = [deferred]
     tracker.pr = "https://github/pr/9"
@@ -488,7 +568,7 @@ def test_running_work_has_priority_over_deferred_and_ready() -> None:
     result = AutomationService(tracker, runner).tick(AUTOMATION)
 
     assert result.task is not None
-    assert result.task.external_id == running.external_id
+    assert result.task.source_issue == running.source_issue
     assert result.task.state is TaskState.REVIEW
     assert tracker.claims == []
 
@@ -524,8 +604,13 @@ def test_running_task_with_existing_pr_preserves_session_handoff() -> None:
 def test_running_task_resumes_persisted_worker_and_reconciles() -> None:
     tracker = FakeTracker()
     tracker.list_running = lambda: [replace(TASK, state=TaskState.RUNNING)]  # type: ignore[method-assign]
-    pull_requests = iter([None, "https://github/pr/9"])
-    tracker.find_pull_request = lambda task: next(pull_requests)  # type: ignore[method-assign]
+    pull_requests = iter(
+        [
+            PullRequestReconciliation(),
+            PullRequestReconciliation("https://github/pr/9"),
+        ]
+    )
+    tracker.reconcile_pull_requests = lambda task: next(pull_requests)  # type: ignore[method-assign]
     runner = FakeRunner(WorkResult(True, pull_request_url="https://github/pr/9"))
     result = AutomationService(tracker, runner).tick(AUTOMATION)
     assert result.status == "review"


### PR DESCRIPTION
## Why

Local automations currently assume that the issue queue, implementation checkout, and resulting pull request all belong to one repository. That prevents a private control queue from safely driving work in another repository.

## What changed

Automation configuration now requires separate `source` and `target` mappings. The source owns issue discovery, dependencies, labels, comments, and lifecycle state. The target owns the implementation checkout, rendered repository context, and draft pull request.

This is an intentional clean break: `source.repository-path` is removed, `target.repository` and `target.repository-path` are required, and automation JSON output is version 2.

Pull-request reconciliation is rooted at the exact source issue's repository-qualified closing references, filters to the configured target repository, and fails closed on incomplete pagination. An accepted open draft takes precedence; otherwise an exact non-draft or closed target PR is reported as a policy violation before Pi starts or resumes.

Target preflight also verifies that the configured path is a Git worktree whose GitHub `origin` matches the declared target repository.

## Proof

- Full lint, formatting, strict typing, and non-E2E gate: 352 tests passed with 88% coverage.
- Installed CLI lifecycle suite: 35 passed; one optional Claude-backed test skipped.
- Strict documentation build passed.
- Independent architecture, correctness, pytest, and AI-antipattern review found no remaining P0–P2 blockers.

The active global Groundskeeper installation and existing scheduled factory were not changed during validation.