### PR TITLE
feat(automation): add isolated checkout policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ automations:
     target:
       repository: example/widgets
       repository-path: /Users/you/src/widgets
+      checkout:
+        mode: isolated-worktree
+        base-ref: origin/main
+        refresh: fetch
     runner:
       type: pi
       skill: issue-implementation
@@ -44,7 +48,8 @@ automations:
 Create `issue-implementation` as an ordinary skill under
 `.groundskeeper/skills/`. It receives its usual prompt plus `TASK_ID`,
 `TASK_TITLE`, `TASK_BODY`, `TASK_URL`, `REPOSITORY`,
-`FACTORY_CLOSING_REFERENCE`, `RECOVERY_CONTEXT`, and the fixed
+`FACTORY_CLOSING_REFERENCE`, `RECOVERY_CONTEXT`, typed `TARGET_CHECKOUT_MODE`,
+`TARGET_BASE_REF`, `TARGET_BASE_SHA`, `TARGET_REFRESH`, and the fixed
 `POLICY_CONCURRENCY`, `POLICY_OUTPUT`, and `POLICY_MERGE` fields. `REPOSITORY`
 is the target repository. The closing reference is `#123` for a same-repository
 queue or `example/work-factory#123` for a cross-repository queue.
@@ -59,8 +64,14 @@ gk automation tick daily-maintenance --json
 
 `validate` checks configuration, skill resolution, the Pi executable, fixed
 policy, and that the target path is a Git worktree whose GitHub `origin` matches
-the configured target, without contacting GitHub or claiming work. Dry-run and
-live tick perform that checkout preflight before tracker access. Source issue
+the configured target, without contacting GitHub or claiming work. For an
+`isolated-worktree` target it also resolves the configured base ref. A live tick
+with `refresh: fetch` refreshes the exact `origin/*` branch under the host lock,
+then passes its immutable commit SHA to the worker before tracker access.
+Validation and dry-run never fetch. The target path is a donor checkout; its
+dirty working tree is neither inspected nor modified by Groundskeeper. The
+configured skill must create or reuse its isolated task worktree from
+`TARGET_BASE_SHA`. Source issue
 discovery, admission, labels, dependencies, and comments stay in the source
 repository. Pi runs in the target path. Pull-request reconciliation queries the
 exact source issue's closing-PR connection and filters results to the target

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Create `issue-implementation` as an ordinary skill under
 `.groundskeeper/skills/`. It receives its usual prompt plus `TASK_ID`,
 `TASK_TITLE`, `TASK_BODY`, `TASK_URL`, `REPOSITORY`,
 `FACTORY_CLOSING_REFERENCE`, `RECOVERY_CONTEXT`, typed `TARGET_CHECKOUT_MODE`,
-`TARGET_BASE_REF`, `TARGET_BASE_SHA`, `TARGET_REFRESH`, and the fixed
+`TARGET_BASE_REF`, `TARGET_BASE_SHA`, `TARGET_REFRESH`,
+`TARGET_WORKSPACE_PATH`, and the fixed
 `POLICY_CONCURRENCY`, `POLICY_OUTPUT`, and `POLICY_MERGE` fields. `REPOSITORY`
 is the target repository. The closing reference is `#123` for a same-repository
 queue or `example/work-factory#123` for a cross-repository queue.
@@ -67,19 +68,21 @@ policy, and that the target path is a Git worktree whose GitHub `origin` matches
 the configured target, without contacting GitHub or claiming work. For an
 `isolated-worktree` target it also resolves the configured base ref. A live tick
 with `refresh: fetch` refreshes the exact `origin/*` branch under the host lock,
-then passes its immutable commit SHA to the worker before tracker access.
+then freezes its commit SHA before tracker access.
 Validation and dry-run never fetch. The target path is a donor checkout; its
-dirty working tree is neither inspected nor modified by Groundskeeper. The
-configured skill must create or reuse its isolated task worktree from
-`TARGET_BASE_SHA`. Source issue
+dirty working tree is neither inspected nor modified by Groundskeeper. After
+claim, Groundskeeper creates a deterministic task branch and worktree from the
+frozen SHA, runs Pi there, and reuses that same worktree and original base when
+recovering the deterministic session. Source issue
 discovery, admission, labels, dependencies, and comments stay in the source
-repository. Pi runs in the target path. Pull-request reconciliation queries the
+repository. Pull-request reconciliation queries the
 exact source issue's closing-PR connection and filters results to the target
 repository. `tick` is noninteractive and uses a host-local
-advisory lock keyed by canonical source repository identity. Locks live under `$XDG_STATE_HOME/groundskeeper/locks`
-(or `~/.local/state/groundskeeper/locks`), so separate config worktrees for the
-same repository share one host lock. `GROUNDSKEEPER_STATE_HOME` is a narrow
-host/test override. Run exactly one scheduler host for each automation;
+source-queue lock plus a target donor/worktree lock. Locks and deterministic
+task worktrees live under `$XDG_STATE_HOME/groundskeeper`
+(or `~/.local/state/groundskeeper`), so separate config worktrees share the
+same host coordination and recovery state. `GROUNDSKEEPER_STATE_HOME` is a
+narrow host/test override. Run exactly one scheduler host for each automation;
 multi-host scheduling is not supported. A tick reconciles running work first,
 then atomically reclaims deferred work, then claims new ready work. A successful
 no-work tick is safe. Before dispatch and after any worker return, Groundskeeper

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -82,16 +82,17 @@ automation config
   → strict source queue, target repository/path/checkout, runner, labels, timeout, and policy parsing
   → resolve configured skill with provenance
   → validation/dry-run: prove target identity and resolve the optional base without donor mutation
-  → live tick: acquire the stable host-state lock for canonical source repository identity
+  → live tick: acquire stable source-admission and target-workspace host locks
   → live tick: prove target identity, optionally fetch the exact origin branch, and freeze its commit SHA
   → reconcile running issues before deferred work before ready work
   → parse one exact Factory Task + Dependencies contract and resolve dependency state
   → block malformed, tracking, inaccessible, unresolved, or closed-unmerged dependency work before Pi
   → atomically claim at most one admitted trusted deferred or ready task
+  → create or reuse the deterministic task branch/worktree from its pinned original base
   → normalize the repository-qualified source issue and explicit target identity
   → render configured skill + typed closing/task-contract/checkout/recovery/policy/session context
   → require POSIX process-group isolation
-  → run Pi in the target checkout with a deterministic session keyed by source + issue + target
+  → run Pi in the task worktree with a deterministic session keyed by source + issue + target
       stdout + stderr → separately preserved and tee'd to live scheduler logs
       stdout → PR URL parsing + strict public blocker marker extraction
       stderr → transient/durable provider failure classification
@@ -121,12 +122,14 @@ session. A repeat transient failure returns it to `deferred`; a later accepted
 draft PR reaches `review`.
 
 The source repository owns discovery, admission, dependencies, labels, comments,
-and lifecycle. The target repository/path/checkout contract owns Pi cwd,
-rendered `REPOSITORY`, immutable task-worktree base identity, and accepted draft
-PR discovery. The workflow instructions belong to the
-configured skill; the Pi adapter knows only how to execute a rendered prompt. `merge: never` is an accepted-result
-contract, not a credential sandbox. Host-state locking coordinates config
-worktrees on one machine and does not provide distributed locking.
+and lifecycle. The target checkout module owns donor validation and refresh,
+immutable task-base pinning, deterministic branch/worktree recovery, and Pi cwd.
+The target repository also scopes rendered `REPOSITORY` and accepted draft PR
+discovery. Workflow instructions belong to the configured skill; they do not
+own Git checkout mechanics. The Pi adapter knows only how to execute a rendered
+prompt. `merge: never` is an accepted-result contract, not a credential sandbox.
+Host-state locking coordinates source admission and target workspaces on one
+machine and does not provide distributed locking.
 
 ## CI Generation Flow
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,16 +79,17 @@ For workflows: steps execute sequentially. `ParallelGroup` steps use `ThreadPool
 
 ```text
 automation config
-  → strict source queue, target repository/path, runner, labels, timeout, and policy parsing
+  → strict source queue, target repository/path/checkout, runner, labels, timeout, and policy parsing
   → resolve configured skill with provenance
-  → prove target path is a Git worktree whose origin matches target repository
-  → acquire stable host-state lock for canonical source repository identity
+  → validation/dry-run: prove target identity and resolve the optional base without donor mutation
+  → live tick: acquire the stable host-state lock for canonical source repository identity
+  → live tick: prove target identity, optionally fetch the exact origin branch, and freeze its commit SHA
   → reconcile running issues before deferred work before ready work
   → parse one exact Factory Task + Dependencies contract and resolve dependency state
   → block malformed, tracking, inaccessible, unresolved, or closed-unmerged dependency work before Pi
   → atomically claim at most one admitted trusted deferred or ready task
   → normalize the repository-qualified source issue and explicit target identity
-  → render configured skill + typed closing/task-contract/recovery/policy/session context
+  → render configured skill + typed closing/task-contract/checkout/recovery/policy/session context
   → require POSIX process-group isolation
   → run Pi in the target checkout with a deterministic session keyed by source + issue + target
       stdout + stderr → separately preserved and tee'd to live scheduler logs
@@ -120,8 +121,9 @@ session. A repeat transient failure returns it to `deferred`; a later accepted
 draft PR reaches `review`.
 
 The source repository owns discovery, admission, dependencies, labels, comments,
-and lifecycle. The target repository/path owns Pi cwd, rendered `REPOSITORY`,
-and accepted draft PR discovery. The workflow instructions belong to the
+and lifecycle. The target repository/path/checkout contract owns Pi cwd,
+rendered `REPOSITORY`, immutable task-worktree base identity, and accepted draft
+PR discovery. The workflow instructions belong to the
 configured skill; the Pi adapter knows only how to execute a rendered prompt. `merge: never` is an accepted-result
 contract, not a credential sandbox. Host-state locking coordinates config
 worktrees on one machine and does not provide distributed locking.

--- a/docs/config-and-skills.md
+++ b/docs/config-and-skills.md
@@ -26,7 +26,9 @@ A Pi runner must explicitly name `skill`, use `approval: allow`, and use
 identities. The source requires `repository` and at least one `trusted-author`;
 the target requires `repository` and an absolute `repository-path`. Validation,
 dry-run, and live tick prove that path is a Git worktree whose `origin` GitHub
-HTTPS or SSH remote matches the configured target before tracker access. Safety
+HTTPS or SSH remote matches the configured target before tracker access. An
+optional strict `target.checkout` block selects an existing checkout or an
+isolated-worktree donor contract. Safety
 policy is strict: concurrency is `1`, output is `draft-pr`, and merge is `never`.
 Groundskeeper validates this policy and enforces the accepted-result
 postcondition: only an open draft pull request in the target repository that
@@ -34,7 +36,9 @@ closes the exact repository-qualified source issue reaches review. It does not
 sandbox a user-authorized Pi process. An automation skill receives normalized
 `TASK_ID`, `TASK_TITLE`, `TASK_BODY`, `TASK_URL`, target `REPOSITORY`, typed
 `FACTORY_CLOSING_REFERENCE`, `RECOVERY_CONTEXT`, and `POLICY_CONCURRENCY`,
-`POLICY_OUTPUT`, and `POLICY_MERGE`; ordinary skill rendering is unchanged.
+`POLICY_OUTPUT`, and `POLICY_MERGE`; checkout-aware workers also receive
+`TARGET_CHECKOUT_MODE`, `TARGET_BASE_REF`, `TARGET_BASE_SHA`, and
+`TARGET_REFRESH`. Ordinary skill rendering is unchanged.
 
 Every GitHub Issues automation task must begin with exactly these first two H2
 sections. The contract sections cannot contain comments or fenced examples:
@@ -79,7 +83,21 @@ source:
 target:
   repository: example/widgets
   repository-path: /srv/widgets
+  checkout:
+    mode: isolated-worktree
+    base-ref: origin/main
+    refresh: fetch
 ```
+
+When `checkout` is omitted, `mode: existing` preserves the original behavior
+and Pi runs in `repository-path`. `mode: isolated-worktree` requires an explicit
+`base-ref`. `refresh: none` resolves the locally available ref without network
+mutation. `refresh: fetch` requires an `origin/*` base and, for a live tick only,
+fetches that exact branch under the repository lock before tracker access.
+Groundskeeper then passes the resolved commit as `TARGET_BASE_SHA`; the skill
+owns task-worktree creation and reuse. Groundskeeper never checks, cleans,
+stashes, resets, checks out, or edits the donor working tree. Fetch failure or
+an unresolved base stops before issue claim or worker launch.
 
 Pi runners accept optional positive `timeout-seconds` (default: `7200`) for
 long-running development work. GitHub CLI operations use a fixed 30-second

--- a/docs/config-and-skills.md
+++ b/docs/config-and-skills.md
@@ -28,7 +28,7 @@ the target requires `repository` and an absolute `repository-path`. Validation,
 dry-run, and live tick prove that path is a Git worktree whose `origin` GitHub
 HTTPS or SSH remote matches the configured target before tracker access. An
 optional strict `target.checkout` block selects an existing checkout or an
-isolated-worktree donor contract. Safety
+isolated Groundskeeper-managed task worktree. Safety
 policy is strict: concurrency is `1`, output is `draft-pr`, and merge is `never`.
 Groundskeeper validates this policy and enforces the accepted-result
 postcondition: only an open draft pull request in the target repository that
@@ -38,7 +38,8 @@ sandbox a user-authorized Pi process. An automation skill receives normalized
 `FACTORY_CLOSING_REFERENCE`, `RECOVERY_CONTEXT`, and `POLICY_CONCURRENCY`,
 `POLICY_OUTPUT`, and `POLICY_MERGE`; checkout-aware workers also receive
 `TARGET_CHECKOUT_MODE`, `TARGET_BASE_REF`, `TARGET_BASE_SHA`, and
-`TARGET_REFRESH`. Ordinary skill rendering is unchanged.
+`TARGET_REFRESH`, plus the selected `TARGET_WORKSPACE_PATH`. Ordinary skill
+rendering is unchanged.
 
 Every GitHub Issues automation task must begin with exactly these first two H2
 sections. The contract sections cannot contain comments or fenced examples:
@@ -94,10 +95,22 @@ and Pi runs in `repository-path`. `mode: isolated-worktree` requires an explicit
 `base-ref`. `refresh: none` resolves the locally available ref without network
 mutation. `refresh: fetch` requires an `origin/*` base and, for a live tick only,
 fetches that exact branch under the repository lock before tracker access.
-Groundskeeper then passes the resolved commit as `TARGET_BASE_SHA`; the skill
-owns task-worktree creation and reuse. Groundskeeper never checks, cleans,
+After claim, Groundskeeper atomically pins that resolved commit for the task,
+creates a deterministic branch and worktree under its host state directory, and
+runs Pi there. Deferred/running recovery reuses the same worktree and original
+base even if the configured ref has advanced. The configured skill owns workflow
+instructions, not Git checkout lifecycle. Groundskeeper never checks, cleans,
 stashes, resets, checks out, or edits the donor working tree. Fetch failure or
-an unresolved base stops before issue claim or worker launch.
+an unresolved base stops before issue claim; worktree invariant failures stop
+before worker launch and leave claimed work recoverable on the next tick.
+
+Task worktrees, their local branches, and pinned base refs are retained after a
+terminal transition so draft-PR review and deterministic recovery never lose
+local state. Groundskeeper currently performs no automatic garbage collection.
+Operators may remove a task worktree with normal `git worktree remove` and then
+delete its `groundskeeper/task-*` branch and `refs/groundskeeper/bases/*` ref
+only after the task and pull request no longer need recovery. Automated,
+lock-protected retention policy remains future work.
 
 Pi runners accept optional positive `timeout-seconds` (default: `7200`) for
 long-running development work. GitHub CLI operations use a fixed 30-second

--- a/docs/future-work.md
+++ b/docs/future-work.md
@@ -10,6 +10,14 @@ index:
 
 # Future Work
 
+## Automation task-worktree retention
+
+`target.checkout.mode: isolated-worktree` deliberately retains one deterministic
+worktree, local branch, and pinned base ref per task for review and recovery.
+Add a lock-protected inspection and garbage-collection command that removes only
+workspaces whose tracker task and pull request are durably terminal. It must
+preserve active, deferred, running, and reviewable work by default.
+
 ## Worktree-isolated parallel execution (`--parallel --isolate`)
 
 Currently, parallel stages run skills in the same working directory via ThreadPoolExecutor. This is safe for read-only skills but risky for writers. Full isolation would give each skill in a parallel group its own git worktree:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,8 +43,10 @@ whose `origin` identifies `target.repository`, without contacting GitHub or
 starting work. For `isolated-worktree` targets it also resolves the configured
 base ref. Dry-run performs the same read-only checkout preflight. A live tick
 with `refresh: fetch` fetches the configured `origin/*` branch under the host
-lock and passes its resolved commit SHA to the skill before tracker access.
-Neither path checks or modifies donor working-tree files. `tick` runs one bounded reconciliation pass. Dry-run
+lock and freezes its resolved commit SHA before tracker access. After claim it
+creates or reuses the deterministic task worktree and starts Pi there. Recovery
+retains the original task base even when the configured ref advances. Neither
+path checks or modifies donor working-tree files. `tick` runs one bounded reconciliation pass. Dry-run
 selects and reports eligible work without labels, comments, or worker launch.
 Invalid, tracking, missing-contract, or unresolved-dependency work reports
 `would-block` in dry-run and transitions to blocked only in a live tick.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -40,8 +40,11 @@ source and target separately while dry-run continues to omit issue bodies.
 `validate` checks strict config, named-skill resolution, Pi availability, the
 fixed draft-only/never-merge policy, and that the target path is a Git worktree
 whose `origin` identifies `target.repository`, without contacting GitHub or
-starting work. Dry-run and live tick perform the same checkout-identity
-preflight before tracker access. `tick` runs one bounded reconciliation pass. Dry-run
+starting work. For `isolated-worktree` targets it also resolves the configured
+base ref. Dry-run performs the same read-only checkout preflight. A live tick
+with `refresh: fetch` fetches the configured `origin/*` branch under the host
+lock and passes its resolved commit SHA to the skill before tracker access.
+Neither path checks or modifies donor working-tree files. `tick` runs one bounded reconciliation pass. Dry-run
 selects and reports eligible work without labels, comments, or worker launch.
 Invalid, tracking, missing-contract, or unresolved-dependency work reports
 `would-block` in dry-run and transitions to blocked only in a live tick.

--- a/groundskeeper/adapters/automation_runner.py
+++ b/groundskeeper/adapters/automation_runner.py
@@ -13,7 +13,11 @@ from groundskeeper.domain.automation import (
     SessionMetadata,
     WorkResult,
 )
-from groundskeeper.domain.config import AutomationPolicy, PiRunnerConfig
+from groundskeeper.domain.config import (
+    AutomationCheckout,
+    AutomationPolicy,
+    PiRunnerConfig,
+)
 from groundskeeper.domain.models import Skill
 
 
@@ -28,9 +32,17 @@ class PiPromptExecutor(Protocol):
 class AutomationSkillRenderer:
     """Adds normalized task context to a configured Groundskeeper skill."""
 
-    def __init__(self, skill: Skill, policy: AutomationPolicy) -> None:
+    def __init__(
+        self,
+        skill: Skill,
+        policy: AutomationPolicy,
+        checkout: AutomationCheckout,
+        base_sha: str | None = None,
+    ) -> None:
         self._skill = skill
         self._policy = policy
+        self._checkout = checkout
+        self._base_sha = base_sha
 
     def render(
         self,
@@ -41,7 +53,7 @@ class AutomationSkillRenderer:
         """Render a skill without changing ordinary skill rendering behavior."""
         return (
             f"{self._skill.render()}\n\n"
-            f"{self._context(task, recovery, self._policy, settings)}"
+            f"{self._context(task, recovery, self._policy, self._checkout, self._base_sha, settings)}"
         )
 
     @staticmethod
@@ -49,6 +61,8 @@ class AutomationSkillRenderer:
         task: AdmittedTask,
         recovery: bool,
         policy: AutomationPolicy,
+        checkout: AutomationCheckout,
+        base_sha: str | None,
         settings: PiExecutionSettings,
     ) -> str:
         recovery_context = (
@@ -72,6 +86,10 @@ class AutomationSkillRenderer:
                 f"FACTORY_TASK_KIND: {contract.kind.value}",
                 f"FACTORY_EXECUTION_MODE: {contract.mode.value if contract.mode else ''}",
                 "FACTORY_DEPENDENCY_STATUS: resolved",
+                f"TARGET_CHECKOUT_MODE: {checkout.mode}",
+                f"TARGET_BASE_REF: {checkout.base_ref or ''}",
+                f"TARGET_BASE_SHA: {base_sha or ''}",
+                f"TARGET_REFRESH: {checkout.refresh}",
                 f"POLICY_CONCURRENCY: {policy.concurrency}",
                 f"POLICY_OUTPUT: {policy.output}",
                 f"POLICY_MERGE: {policy.merge}",

--- a/groundskeeper/adapters/automation_runner.py
+++ b/groundskeeper/adapters/automation_runner.py
@@ -7,11 +7,16 @@ from pathlib import Path
 from typing import Protocol
 
 from groundskeeper.adapters.pi import PiExecutionSettings
+from groundskeeper.adapters.target_checkout import (
+    TargetCheckoutManager,
+    TargetWorkspace,
+)
 from groundskeeper.domain.automation import (
     AdmittedTask,
     AutomationTask,
     SessionMetadata,
     WorkResult,
+    automation_task_identity,
 )
 from groundskeeper.domain.config import (
     AutomationCheckout,
@@ -37,23 +42,22 @@ class AutomationSkillRenderer:
         skill: Skill,
         policy: AutomationPolicy,
         checkout: AutomationCheckout,
-        base_sha: str | None = None,
     ) -> None:
         self._skill = skill
         self._policy = policy
         self._checkout = checkout
-        self._base_sha = base_sha
 
     def render(
         self,
         task: AdmittedTask,
         recovery: bool,
         settings: PiExecutionSettings,
+        workspace: TargetWorkspace,
     ) -> str:
         """Render a skill without changing ordinary skill rendering behavior."""
         return (
             f"{self._skill.render()}\n\n"
-            f"{self._context(task, recovery, self._policy, self._checkout, self._base_sha, settings)}"
+            f"{self._context(task, recovery, self._policy, self._checkout, workspace, settings)}"
         )
 
     @staticmethod
@@ -62,7 +66,7 @@ class AutomationSkillRenderer:
         recovery: bool,
         policy: AutomationPolicy,
         checkout: AutomationCheckout,
-        base_sha: str | None,
+        workspace: TargetWorkspace,
         settings: PiExecutionSettings,
     ) -> str:
         recovery_context = (
@@ -88,8 +92,9 @@ class AutomationSkillRenderer:
                 "FACTORY_DEPENDENCY_STATUS: resolved",
                 f"TARGET_CHECKOUT_MODE: {checkout.mode}",
                 f"TARGET_BASE_REF: {checkout.base_ref or ''}",
-                f"TARGET_BASE_SHA: {base_sha or ''}",
+                f"TARGET_BASE_SHA: {workspace.base_sha or ''}",
                 f"TARGET_REFRESH: {checkout.refresh}",
+                f"TARGET_WORKSPACE_PATH: {workspace.path}",
                 f"POLICY_CONCURRENCY: {policy.concurrency}",
                 f"POLICY_OUTPUT: {policy.output}",
                 f"POLICY_MERGE: {policy.merge}",
@@ -107,22 +112,19 @@ class PiAutomationRunner:
     def __init__(
         self,
         client: PiPromptExecutor,
-        repository_path: Path,
+        checkout_manager: TargetCheckoutManager,
         renderer: AutomationSkillRenderer,
         config: PiRunnerConfig,
     ) -> None:
         self._client = client
-        self._repository_path = repository_path
+        self._checkout_manager = checkout_manager
         self._renderer = renderer
         self._config = config
 
     def _settings(self, task: AutomationTask) -> PiExecutionSettings:
         source_repository = task.source_issue.repository.casefold()
         target_repository = task.target_repository.casefold()
-        identity = (
-            f"groundskeeper:{source_repository}:{task.source_issue.number}:"
-            f"{target_repository}"
-        )
+        identity = automation_task_identity(task)
         return PiExecutionSettings(
             session_id=str(uuid.uuid5(uuid.NAMESPACE_URL, identity)),
             name=(
@@ -144,8 +146,9 @@ class PiAutomationRunner:
 
     def run(self, task: AdmittedTask, recovery: bool = False) -> WorkResult:
         settings = self._settings(task.task)
+        workspace = self._checkout_manager.workspace_for(task.task)
         return self._client.run_prompt(
-            self._renderer.render(task, recovery, settings),
-            self._repository_path,
+            self._renderer.render(task, recovery, settings, workspace),
+            workspace.path,
             settings,
         )

--- a/groundskeeper/adapters/target_checkout.py
+++ b/groundskeeper/adapters/target_checkout.py
@@ -256,7 +256,7 @@ def prepare_target_checkout(
                 "fetch",
                 "--no-tags",
                 "origin",
-                f"refs/heads/{branch}:refs/remotes/origin/{branch}",
+                f"+refs/heads/{branch}:refs/remotes/origin/{branch}",
             ),
             repository_path,
             timeout=GIT_PREFLIGHT_TIMEOUT_SECONDS,

--- a/groundskeeper/adapters/target_checkout.py
+++ b/groundskeeper/adapters/target_checkout.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
 from groundskeeper.adapters.process import ProcessClient
-from groundskeeper.domain.automation import canonical_github_repository
+from groundskeeper.domain.automation import (
+    AutomationTask,
+    automation_task_identity,
+    canonical_github_repository,
+)
 from groundskeeper.domain.config import AutomationCheckout
 
 GIT_PREFLIGHT_TIMEOUT_SECONDS = 30
@@ -16,6 +22,183 @@ _SCP_GITHUB_REMOTE_RE = re.compile(r"^[^@/:]+@github\.com:(?P<repository>[^/]+/[
 
 class TargetCheckoutError(RuntimeError):
     """The configured target path does not identify the declared repository."""
+
+
+def target_checkout_common_dir(process: ProcessClient, path: Path) -> Path:
+    """Return the normalized Git metadata directory shared by linked worktrees."""
+    result = process.run(
+        ("git", "rev-parse", "--git-common-dir"),
+        path,
+        timeout=GIT_PREFLIGHT_TIMEOUT_SECONDS,
+    )
+    if not result.success or not result.stdout.strip():
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        raise TargetCheckoutError(
+            f"could not identify target workspace Git directory: {detail}"
+        )
+    common_dir = Path(result.stdout.strip())
+    return (
+        common_dir.resolve()
+        if common_dir.is_absolute()
+        else (path / common_dir).resolve()
+    )
+
+
+@dataclass(frozen=True)
+class TargetWorkspace:
+    """Execution checkout and its immutable task base."""
+
+    path: Path
+    base_sha: str | None
+
+
+class TargetCheckoutManager:
+    """Own deterministic task worktrees above one validated donor checkout."""
+
+    def __init__(
+        self,
+        process: ProcessClient,
+        repository_path: Path,
+        expected_repository: str,
+        checkout: AutomationCheckout,
+        candidate_base_sha: str | None,
+        state_root: Path,
+    ) -> None:
+        self._process = process
+        self._repository_path = repository_path
+        self._expected_repository = expected_repository
+        self._checkout = checkout
+        self._candidate_base_sha = candidate_base_sha
+        self._state_root = state_root
+
+    def workspace_for(self, task: AutomationTask) -> TargetWorkspace:
+        """Create or reuse the task checkout selected by the typed policy."""
+        if task.target_repository.casefold() != self._expected_repository.casefold():
+            raise TargetCheckoutError(
+                "task target repository does not match the prepared checkout: "
+                f"expected {self._expected_repository}, found {task.target_repository}"
+            )
+        if self._checkout.mode == "existing":
+            return TargetWorkspace(self._repository_path, None)
+        if self._candidate_base_sha is None:
+            raise TargetCheckoutError(
+                "isolated-worktree checkout has no resolved candidate base"
+            )
+
+        task_key = hashlib.sha256(
+            automation_task_identity(task).encode("utf-8")
+        ).hexdigest()[:16]
+        target_key = hashlib.sha256(
+            (
+                f"{self._expected_repository.casefold()}\0"
+                f"{target_checkout_common_dir(self._process, self._repository_path)}"
+            ).encode()
+        ).hexdigest()[:16]
+        workspace_path = self._state_root / "worktrees" / target_key / task_key
+        branch = f"groundskeeper/task-{task_key}"
+        branch_ref = f"refs/heads/{branch}"
+        base_ref = f"refs/groundskeeper/bases/{task_key}"
+        workspace_exists = workspace_path.exists()
+        branch_exists = self._resolve_optional_ref(branch_ref) is not None
+        pinned_base = self._resolve_optional_ref(base_ref)
+        if pinned_base is None:
+            if workspace_exists or branch_exists:
+                raise TargetCheckoutError(
+                    "target workspace state exists without its immutable base pin; "
+                    f"manual recovery is required for {workspace_path}"
+                )
+            self._run_or_raise(
+                ("git", "update-ref", base_ref, self._candidate_base_sha, ""),
+                "could not pin the immutable task base",
+            )
+            pinned_base = self._candidate_base_sha
+
+        if workspace_exists:
+            if not workspace_path.is_dir():
+                raise TargetCheckoutError(
+                    f"target workspace path is not a directory: {workspace_path}"
+                )
+            if not branch_exists:
+                raise TargetCheckoutError(
+                    "target workspace exists without its deterministic branch: "
+                    f"{workspace_path}"
+                )
+            self._validate_reused_workspace(workspace_path, branch_ref)
+        else:
+            try:
+                workspace_path.parent.mkdir(parents=True, exist_ok=True)
+            except OSError as error:
+                raise TargetCheckoutError(
+                    f"could not create target workspace directory: {error}"
+                ) from error
+            if branch_exists:
+                argv = ("git", "worktree", "add", str(workspace_path), branch)
+            else:
+                argv = (
+                    "git",
+                    "worktree",
+                    "add",
+                    "-b",
+                    branch,
+                    str(workspace_path),
+                    pinned_base,
+                )
+            self._run_or_raise(argv, "could not create or recover the target workspace")
+        return TargetWorkspace(workspace_path, pinned_base)
+
+    def _resolve_optional_ref(self, ref: str) -> str | None:
+        result = self._process.run(
+            (
+                "git",
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                "--end-of-options",
+                f"{ref}^{{commit}}",
+            ),
+            self._repository_path,
+            timeout=GIT_PREFLIGHT_TIMEOUT_SECONDS,
+        )
+        if result.success and result.stdout.strip():
+            return result.stdout.strip()
+        if result.exit_code == 1:
+            return None
+        detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+        raise TargetCheckoutError(
+            f"could not resolve target workspace ref {ref}: {detail}"
+        )
+
+    def _validate_reused_workspace(
+        self, workspace_path: Path, expected_branch_ref: str
+    ) -> None:
+        donor_common_dir = target_checkout_common_dir(
+            self._process, self._repository_path
+        )
+        workspace_common_dir = target_checkout_common_dir(self._process, workspace_path)
+        if workspace_common_dir != donor_common_dir:
+            raise TargetCheckoutError(
+                "target workspace belongs to a different Git repository: "
+                f"{workspace_path}"
+            )
+        branch = self._process.run(
+            ("git", "symbolic-ref", "--quiet", "HEAD"),
+            workspace_path,
+            timeout=GIT_PREFLIGHT_TIMEOUT_SECONDS,
+        )
+        if not branch.success or branch.stdout.strip() != expected_branch_ref:
+            raise TargetCheckoutError(
+                f"target workspace is not on its deterministic branch: {workspace_path}"
+            )
+
+    def _run_or_raise(self, argv: tuple[str, ...], action: str) -> None:
+        result = self._process.run(
+            argv,
+            self._repository_path,
+            timeout=GIT_PREFLIGHT_TIMEOUT_SECONDS,
+        )
+        if not result.success:
+            detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+            raise TargetCheckoutError(f"{action}: {detail}")
 
 
 def _repository_from_remote(remote: str) -> str:

--- a/groundskeeper/adapters/target_checkout.py
+++ b/groundskeeper/adapters/target_checkout.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 from groundskeeper.adapters.process import ProcessClient
 from groundskeeper.domain.automation import canonical_github_repository
+from groundskeeper.domain.config import AutomationCheckout
 
 GIT_PREFLIGHT_TIMEOUT_SECONDS = 30
 _SCP_GITHUB_REMOTE_RE = re.compile(r"^[^@/:]+@github\.com:(?P<repository>[^/]+/[^/]+)$")
@@ -41,6 +42,49 @@ def _repository_from_remote(remote: str) -> str:
 
 
 def validate_target_checkout(
+    process: ProcessClient,
+    repository_path: Path,
+    expected_repository: str,
+    checkout: AutomationCheckout | None = None,
+) -> str | None:
+    """Prove the donor path, origin, and configured base ref without mutation."""
+    checkout = checkout or AutomationCheckout()
+    _validate_target_repository(process, repository_path, expected_repository)
+    return _validate_base_ref(process, repository_path, checkout)
+
+
+def prepare_target_checkout(
+    process: ProcessClient,
+    repository_path: Path,
+    expected_repository: str,
+    checkout: AutomationCheckout,
+) -> str | None:
+    """Refresh and prove a live isolated-worktree donor before tracker access."""
+    _validate_target_repository(process, repository_path, expected_repository)
+    if checkout.mode == "isolated-worktree" and checkout.refresh == "fetch":
+        if (
+            checkout.base_ref is None
+        ):  # Defensive: config parsing already requires this.
+            raise TargetCheckoutError("isolated-worktree checkout requires a base ref")
+        branch = checkout.base_ref.removeprefix("origin/")
+        refresh = process.run(
+            (
+                "git",
+                "fetch",
+                "--no-tags",
+                "origin",
+                f"refs/heads/{branch}:refs/remotes/origin/{branch}",
+            ),
+            repository_path,
+            timeout=GIT_PREFLIGHT_TIMEOUT_SECONDS,
+        )
+        if not refresh.success:
+            detail = refresh.stderr.strip() or refresh.stdout.strip() or "unknown error"
+            raise TargetCheckoutError(f"target checkout refresh failed: {detail}")
+    return _validate_base_ref(process, repository_path, checkout)
+
+
+def _validate_target_repository(
     process: ProcessClient, repository_path: Path, expected_repository: str
 ) -> None:
     """Prove the target path is a Git worktree for the configured origin."""
@@ -68,3 +112,30 @@ def validate_target_checkout(
             "target checkout origin repository does not match target.repository: "
             f"expected {expected_repository}, found {actual_repository}"
         )
+
+
+def _validate_base_ref(
+    process: ProcessClient, repository_path: Path, checkout: AutomationCheckout
+) -> str | None:
+    """Require the typed isolated-worktree base to resolve to one commit."""
+    if checkout.mode == "existing":
+        return None
+    if checkout.base_ref is None:  # Defensive: config parsing already requires this.
+        raise TargetCheckoutError("isolated-worktree checkout requires a base ref")
+    resolved = process.run(
+        (
+            "git",
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            "--end-of-options",
+            f"{checkout.base_ref}^{{commit}}",
+        ),
+        repository_path,
+        timeout=GIT_PREFLIGHT_TIMEOUT_SECONDS,
+    )
+    if not resolved.success or not resolved.stdout.strip():
+        raise TargetCheckoutError(
+            f"target checkout base ref does not resolve to a commit: {checkout.base_ref}"
+        )
+    return resolved.stdout.strip()

--- a/groundskeeper/cli/main.py
+++ b/groundskeeper/cli/main.py
@@ -24,7 +24,10 @@ from groundskeeper.adapters.github_issues import GitHubIssuesTracker
 from groundskeeper.adapters.local_store import LocalSkillStore
 from groundskeeper.adapters.pi import PiClient
 from groundskeeper.adapters.process import ProcessClient
-from groundskeeper.adapters.target_checkout import validate_target_checkout
+from groundskeeper.adapters.target_checkout import (
+    prepare_target_checkout,
+    validate_target_checkout,
+)
 from groundskeeper.adapters.tick_lock import TickLock
 from groundskeeper.automation import AutomationService
 from groundskeeper.domain.config import (
@@ -166,10 +169,7 @@ def _automation_summary(
                 "blocked": item.source.blocked_label,
             },
         },
-        "target": {
-            "repository": item.target.repository,
-            "repository_path": str(item.target.repository_path),
-        },
+        "target": _automation_target_summary(item),
         "runner": {
             "type": item.runner.type,
             "skill": item.runner.skill,
@@ -190,6 +190,19 @@ def _automation_summary(
             "path": str(skill.source.path),
         }
     return summary
+
+
+def _automation_target_summary(item: Automation) -> dict[str, object]:
+    """Return the public typed target and checkout contract."""
+    return {
+        "repository": item.target.repository,
+        "repository_path": str(item.target.repository_path),
+        "checkout": {
+            "mode": item.target.checkout.mode,
+            "base_ref": item.target.checkout.base_ref,
+            "refresh": item.target.checkout.refresh,
+        },
+    }
 
 
 def _automation_envelope(
@@ -264,6 +277,7 @@ def _build_automation_runner(
     extra_skill_paths: tuple[str, ...],
     process: ProcessClient,
     require_available: bool = True,
+    refresh_target: bool = False,
     skill: Skill | None = None,
 ) -> PiAutomationRunner:
     """Construct the one supported typed automation runner after preflight checks."""
@@ -273,7 +287,20 @@ def _build_automation_runner(
             f"Automation '{definition.name}' repository path does not exist: "
             f"{repository_path}"
         )
-    validate_target_checkout(process, repository_path, definition.target.repository)
+    if refresh_target:
+        base_sha = prepare_target_checkout(
+            process,
+            repository_path,
+            definition.target.repository,
+            definition.target.checkout,
+        )
+    else:
+        base_sha = validate_target_checkout(
+            process,
+            repository_path,
+            definition.target.repository,
+            definition.target.checkout,
+        )
     resolved_skill = skill or _resolve_automation_skill(
         definition, config_path, extra_skill_paths
     )
@@ -290,7 +317,12 @@ def _build_automation_runner(
     return PiAutomationRunner(
         client,
         repository_path,
-        AutomationSkillRenderer(resolved_skill, definition.policy),
+        AutomationSkillRenderer(
+            resolved_skill,
+            definition.policy,
+            definition.target.checkout,
+            base_sha,
+        ),
         definition.runner,
     )
 
@@ -481,10 +513,7 @@ def automation_inspect(ctx: click.Context, name: str, json_output: bool) -> None
     data = {
         "automation": name,
         "source": {"repository": definition.source.repository},
-        "target": {
-            "repository": definition.target.repository,
-            "repository_path": str(definition.target.repository_path),
-        },
+        "target": _automation_target_summary(definition),
         "tasks": records,
     }
     if json_output:
@@ -523,20 +552,33 @@ def automation_tick(
     try:
         definition = _load_automation(config_path, name)
         process = ProcessClient()
-        runner = _build_automation_runner(
-            definition, config_path, extra, process, require_available=not dry_run
-        )
-        tracker = GitHubIssuesTracker(
-            GhClient(process, definition.target.repository_path),
-            definition.source,
-            definition.target.repository,
-        )
-        service = AutomationService(tracker, runner)
         if dry_run:
+            runner = _build_automation_runner(
+                definition, config_path, extra, process, require_available=False
+            )
+            tracker = GitHubIssuesTracker(
+                GhClient(process, definition.target.repository_path),
+                definition.source,
+                definition.target.repository,
+            )
+            service = AutomationService(tracker, runner)
             result = service.tick(definition, dry_run=True)
         else:
             lock_path = _automation_lock_path(definition)
             with TickLock(lock_path):
+                runner = _build_automation_runner(
+                    definition,
+                    config_path,
+                    extra,
+                    process,
+                    refresh_target=True,
+                )
+                tracker = GitHubIssuesTracker(
+                    GhClient(process, definition.target.repository_path),
+                    definition.source,
+                    definition.target.repository,
+                )
+                service = AutomationService(tracker, runner)
                 result = service.tick(definition, dry_run=False)
     except (ConfigError, RuntimeError) as error:
         _automation_error(str(error), json_output)
@@ -558,10 +600,7 @@ def automation_tick(
     data: dict[str, object] = {
         "automation": result.automation,
         "source": {"repository": definition.source.repository},
-        "target": {
-            "repository": definition.target.repository,
-            "repository_path": str(definition.target.repository_path),
-        },
+        "target": _automation_target_summary(definition),
         "task": task_data,
         "pull_request_url": result.pull_request_url,
         "detail": result.detail,

--- a/groundskeeper/cli/main.py
+++ b/groundskeeper/cli/main.py
@@ -250,12 +250,12 @@ def _automation_state_root() -> Path:
 
 
 def _automation_lock_path(definition: Automation) -> Path:
-    """Return the source-queue lock used for task admission."""
+    """Return the source-queue lock, preserving the pre-split lock identity."""
     repository_identity = definition.source.repository.casefold()
     repository_key = hashlib.sha256(repository_identity.encode("utf-8")).hexdigest()[
         :16
     ]
-    return _automation_state_root() / "locks" / f"source-{repository_key}.lock"
+    return _automation_state_root() / "locks" / f"repository-{repository_key}.lock"
 
 
 def _automation_target_lock_path(definition: Automation, git_common_dir: Path) -> Path:

--- a/groundskeeper/cli/main.py
+++ b/groundskeeper/cli/main.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import shutil
+from contextlib import ExitStack
 from pathlib import Path
 
 import click
@@ -25,7 +26,9 @@ from groundskeeper.adapters.local_store import LocalSkillStore
 from groundskeeper.adapters.pi import PiClient
 from groundskeeper.adapters.process import ProcessClient
 from groundskeeper.adapters.target_checkout import (
+    TargetCheckoutManager,
     prepare_target_checkout,
+    target_checkout_common_dir,
     validate_target_checkout,
 )
 from groundskeeper.adapters.tick_lock import TickLock
@@ -247,12 +250,21 @@ def _automation_state_root() -> Path:
 
 
 def _automation_lock_path(definition: Automation) -> Path:
-    """Return a stable host-local lock shared by one normalized repository."""
+    """Return the source-queue lock used for task admission."""
     repository_identity = definition.source.repository.casefold()
     repository_key = hashlib.sha256(repository_identity.encode("utf-8")).hexdigest()[
         :16
     ]
-    return _automation_state_root() / "locks" / f"repository-{repository_key}.lock"
+    return _automation_state_root() / "locks" / f"source-{repository_key}.lock"
+
+
+def _automation_target_lock_path(definition: Automation, git_common_dir: Path) -> Path:
+    """Return the lock protecting one target donor and its task worktrees."""
+    target_identity = (
+        f"{definition.target.repository.casefold()}\0{git_common_dir.resolve()}"
+    )
+    target_key = hashlib.sha256(target_identity.encode("utf-8")).hexdigest()[:16]
+    return _automation_state_root() / "locks" / f"target-{target_key}.lock"
 
 
 def _resolve_automation_skill(
@@ -287,6 +299,19 @@ def _build_automation_runner(
             f"Automation '{definition.name}' repository path does not exist: "
             f"{repository_path}"
         )
+    resolved_skill = skill or _resolve_automation_skill(
+        definition, config_path, extra_skill_paths
+    )
+    client = PiClient(process)
+    if require_available and not client.is_available():
+        raise ConfigError(
+            "Pi CLI not found. Install Pi and retry 'gk automation validate'."
+        )
+    if require_available and not client.supports_automation():
+        raise ConfigError(
+            "Pi automation requires POSIX process-group isolation; "
+            "run this automation on macOS or Linux."
+        )
     if refresh_target:
         base_sha = prepare_target_checkout(
             process,
@@ -301,27 +326,21 @@ def _build_automation_runner(
             definition.target.repository,
             definition.target.checkout,
         )
-    resolved_skill = skill or _resolve_automation_skill(
-        definition, config_path, extra_skill_paths
+    checkout_manager = TargetCheckoutManager(
+        process,
+        repository_path,
+        definition.target.repository,
+        definition.target.checkout,
+        base_sha,
+        _automation_state_root(),
     )
-    client = PiClient(process)
-    if require_available and not client.is_available():
-        raise ConfigError(
-            "Pi CLI not found. Install Pi and retry 'gk automation validate'."
-        )
-    if require_available and not client.supports_automation():
-        raise ConfigError(
-            "Pi automation requires POSIX process-group isolation; "
-            "run this automation on macOS or Linux."
-        )
     return PiAutomationRunner(
         client,
-        repository_path,
+        checkout_manager,
         AutomationSkillRenderer(
             resolved_skill,
             definition.policy,
             definition.target.checkout,
-            base_sha,
         ),
         definition.runner,
     )
@@ -564,8 +583,16 @@ def automation_tick(
             service = AutomationService(tracker, runner)
             result = service.tick(definition, dry_run=True)
         else:
-            lock_path = _automation_lock_path(definition)
-            with TickLock(lock_path):
+            target_common_dir = target_checkout_common_dir(
+                process, definition.target.repository_path
+            )
+            with ExitStack() as locks:
+                locks.enter_context(TickLock(_automation_lock_path(definition)))
+                locks.enter_context(
+                    TickLock(
+                        _automation_target_lock_path(definition, target_common_dir)
+                    )
+                )
                 runner = _build_automation_runner(
                     definition,
                     config_path,

--- a/groundskeeper/domain/automation.py
+++ b/groundskeeper/domain/automation.py
@@ -73,6 +73,14 @@ class AutomationTask:
     contract: FactoryTaskContract | None = None
 
 
+def automation_task_identity(task: AutomationTask) -> str:
+    """Return the stable identity shared by sessions and task worktrees."""
+    return (
+        f"groundskeeper:{task.source_issue.repository.casefold()}:"
+        f"{task.source_issue.number}:{task.target_repository.casefold()}"
+    )
+
+
 class AdmissionState(str, Enum):
     """Machine-readable reason that one task may or may not run."""
 

--- a/groundskeeper/domain/config.py
+++ b/groundskeeper/domain/config.py
@@ -141,11 +141,21 @@ class GitHubIssuesSource:
 
 
 @dataclass(frozen=True)
+class AutomationCheckout:
+    """Typed checkout preparation contract for an automation target."""
+
+    mode: Literal["existing", "isolated-worktree"] = "existing"
+    base_ref: str | None = None
+    refresh: Literal["none", "fetch"] = "none"
+
+
+@dataclass(frozen=True)
 class AutomationTarget:
-    """Repository and checkout where the implementation worker runs."""
+    """Repository and donor checkout where the implementation worker starts."""
 
     repository: str
     repository_path: Path
+    checkout: AutomationCheckout = field(default_factory=AutomationCheckout)
 
 
 @dataclass(frozen=True)
@@ -211,6 +221,68 @@ def _parse_skill_ref(entry: Any) -> SkillRef | None:
             allowed_tools=[str(t) for t in tools],
         )
     return None
+
+
+def _parse_automation_checkout(raw: object, entry_path: str) -> AutomationCheckout:
+    """Parse the optional strict target checkout policy."""
+    if raw is None:
+        return AutomationCheckout()
+    checkout = _automation_mapping(raw, f"{entry_path}.target.checkout")
+    _reject_unknown_automation_keys(
+        checkout,
+        {"mode", "base-ref", "refresh"},
+        f"{entry_path}.target.checkout",
+    )
+    mode = checkout.get("mode")
+    if mode not in {"existing", "isolated-worktree"}:
+        raise ConfigError(
+            f"Automation '{entry_path.removeprefix('automations.')}' "
+            "target.checkout.mode must be existing or isolated-worktree"
+        )
+    if mode == "existing":
+        if set(checkout) != {"mode"}:
+            raise ConfigError(
+                "target.checkout base-ref and refresh are only valid for "
+                "mode: isolated-worktree"
+            )
+        return AutomationCheckout()
+
+    base_ref = checkout.get("base-ref")
+    if (
+        not isinstance(base_ref, str)
+        or not base_ref
+        or base_ref.startswith("-")
+        or any(char.isspace() or ord(char) < 32 for char in base_ref)
+    ):
+        raise ConfigError(
+            f"Automation '{entry_path.removeprefix('automations.')}' "
+            "requires non-empty target.checkout.base-ref"
+        )
+    refresh = checkout.get("refresh", "none")
+    if refresh not in {"none", "fetch"}:
+        raise ConfigError(
+            f"Automation '{entry_path.removeprefix('automations.')}' "
+            "target.checkout.refresh must be none or fetch"
+        )
+    if refresh == "fetch":
+        branch = base_ref.removeprefix("origin/")
+        if (
+            branch == base_ref
+            or not branch
+            or branch.startswith("-")
+            or branch.endswith("/")
+            or ".." in branch
+            or "@{" in branch
+            or any(char in "~^:?*[\\" for char in branch)
+        ):
+            raise ConfigError(
+                "target.checkout.refresh: fetch requires base-ref under origin/"
+            )
+    return AutomationCheckout(
+        mode="isolated-worktree",
+        base_ref=base_ref,
+        refresh=cast(Literal["none", "fetch"], refresh),
+    )
 
 
 def _parse_steps(raw_skills: list[Any]) -> list[Step]:
@@ -387,9 +459,10 @@ def get_automations(config: Mapping[str, object]) -> list[Automation]:
         target = _automation_mapping(target, f"{entry_path}.target")
         _reject_unknown_automation_keys(
             target,
-            {"repository", "repository-path"},
+            {"repository", "repository-path", "checkout"},
             f"{entry_path}.target",
         )
+        checkout = _parse_automation_checkout(target.get("checkout"), entry_path)
         if not isinstance(runner, dict):
             raise ConfigError(f"Automation '{name}' requires runner.type: pi")
         runner = _automation_mapping(runner, f"{entry_path}.runner")
@@ -507,6 +580,7 @@ def get_automations(config: Mapping[str, object]) -> list[Automation]:
                 target=AutomationTarget(
                     repository=target_repository,
                     repository_path=path.resolve(),
+                    checkout=checkout,
                 ),
                 runner=PiRunnerConfig(skill=skill, timeout_seconds=timeout_seconds),
                 policy=AutomationPolicy(),

--- a/groundskeeper/domain/config.py
+++ b/groundskeeper/domain/config.py
@@ -225,8 +225,6 @@ def _parse_skill_ref(entry: Any) -> SkillRef | None:
 
 def _parse_automation_checkout(raw: object, entry_path: str) -> AutomationCheckout:
     """Parse the optional strict target checkout policy."""
-    if raw is None:
-        return AutomationCheckout()
     checkout = _automation_mapping(raw, f"{entry_path}.target.checkout")
     _reject_unknown_automation_keys(
         checkout,
@@ -462,7 +460,11 @@ def get_automations(config: Mapping[str, object]) -> list[Automation]:
             {"repository", "repository-path", "checkout"},
             f"{entry_path}.target",
         )
-        checkout = _parse_automation_checkout(target.get("checkout"), entry_path)
+        checkout = (
+            _parse_automation_checkout(target["checkout"], entry_path)
+            if "checkout" in target
+            else AutomationCheckout()
+        )
         if not isinstance(runner, dict):
             raise ConfigError(f"Automation '{name}' requires runner.type: pi")
         runner = _automation_mapping(runner, f"{entry_path}.runner")

--- a/tests/adapters/test_pi.py
+++ b/tests/adapters/test_pi.py
@@ -29,7 +29,11 @@ from groundskeeper.domain.automation import (
     GitHubIssueIdentity,
     WorkResult,
 )
-from groundskeeper.domain.config import AutomationPolicy, PiRunnerConfig
+from groundskeeper.domain.config import (
+    AutomationCheckout,
+    AutomationPolicy,
+    PiRunnerConfig,
+)
 from groundskeeper.domain.models import Skill, SkillSource
 from groundskeeper.domain.task_contract import (
     ExecutionMode,
@@ -75,7 +79,7 @@ def _runner(client: FakePiClient) -> PiAutomationRunner:
     return PiAutomationRunner(
         client,
         Path("/repos/dots"),
-        AutomationSkillRenderer(_skill(), AutomationPolicy()),
+        AutomationSkillRenderer(_skill(), AutomationPolicy(), AutomationCheckout()),
         PiRunnerConfig(skill="issue-implementation"),
     )
 
@@ -104,6 +108,10 @@ def test_pi_runner_renders_normalized_task_context_with_typed_settings() -> None
     assert "FACTORY_TASK_KIND: runnable" in client.prompt
     assert "FACTORY_EXECUTION_MODE: full" in client.prompt
     assert "FACTORY_DEPENDENCY_STATUS: resolved" in client.prompt
+    assert "TARGET_CHECKOUT_MODE: existing" in client.prompt
+    assert "TARGET_BASE_REF: " in client.prompt
+    assert "TARGET_BASE_SHA: " in client.prompt
+    assert "TARGET_REFRESH: none" in client.prompt
     assert "RECOVERY_CONTEXT: Start a new deterministic session" in client.prompt
     assert client.cwd == Path("/repos/dots")
     assert client.settings is not None
@@ -119,6 +127,38 @@ def test_pi_runner_renders_normalized_task_context_with_typed_settings() -> None
         f"FACTORY_RESUME_COMMAND: pi --session {client.settings.session_id}"
         in client.prompt
     )
+
+
+def test_pi_runner_renders_isolated_checkout_contract() -> None:
+    client = FakePiClient()
+    runner = PiAutomationRunner(
+        client,
+        Path("/repos/dots"),
+        AutomationSkillRenderer(
+            _skill(),
+            AutomationPolicy(),
+            AutomationCheckout("isolated-worktree", "origin/main", "fetch"),
+            "abc123",
+        ),
+        PiRunnerConfig(skill="issue-implementation"),
+    )
+    task = AutomationTask(
+        "github",
+        "Fix it",
+        "Acceptance",
+        "https://issue/3",
+        "alex",
+        GitHubIssueIdentity("source/queue", 3),
+        "target/repo",
+        contract=_contract(),
+    )
+
+    runner.run(_admitted(task))
+
+    assert "TARGET_CHECKOUT_MODE: isolated-worktree" in client.prompt
+    assert "TARGET_BASE_REF: origin/main" in client.prompt
+    assert "TARGET_BASE_SHA: abc123" in client.prompt
+    assert "TARGET_REFRESH: fetch" in client.prompt
 
 
 def test_same_repository_task_renders_short_closing_reference() -> None:

--- a/tests/adapters/test_pi.py
+++ b/tests/adapters/test_pi.py
@@ -22,6 +22,10 @@ from groundskeeper.adapters.process import (
     CommandResult,
     ProcessClient,
 )
+from groundskeeper.adapters.target_checkout import (
+    TargetCheckoutManager,
+    TargetWorkspace,
+)
 from groundskeeper.domain.automation import (
     AdmittedTask,
     AutomationTask,
@@ -78,7 +82,14 @@ def _admitted(task: AutomationTask) -> AdmittedTask:
 def _runner(client: FakePiClient) -> PiAutomationRunner:
     return PiAutomationRunner(
         client,
-        Path("/repos/dots"),
+        TargetCheckoutManager(
+            ProcessClient(),
+            Path("/repos/dots"),
+            "target/repo",
+            AutomationCheckout(),
+            None,
+            Path("/state"),
+        ),
         AutomationSkillRenderer(_skill(), AutomationPolicy(), AutomationCheckout()),
         PiRunnerConfig(skill="issue-implementation"),
     )
@@ -112,6 +123,7 @@ def test_pi_runner_renders_normalized_task_context_with_typed_settings() -> None
     assert "TARGET_BASE_REF: " in client.prompt
     assert "TARGET_BASE_SHA: " in client.prompt
     assert "TARGET_REFRESH: none" in client.prompt
+    assert "TARGET_WORKSPACE_PATH: /repos/dots" in client.prompt
     assert "RECOVERY_CONTEXT: Start a new deterministic session" in client.prompt
     assert client.cwd == Path("/repos/dots")
     assert client.settings is not None
@@ -129,19 +141,9 @@ def test_pi_runner_renders_normalized_task_context_with_typed_settings() -> None
     )
 
 
-def test_pi_runner_renders_isolated_checkout_contract() -> None:
-    client = FakePiClient()
-    runner = PiAutomationRunner(
-        client,
-        Path("/repos/dots"),
-        AutomationSkillRenderer(
-            _skill(),
-            AutomationPolicy(),
-            AutomationCheckout("isolated-worktree", "origin/main", "fetch"),
-            "abc123",
-        ),
-        PiRunnerConfig(skill="issue-implementation"),
-    )
+def test_pi_renderer_includes_isolated_checkout_contract() -> None:
+    checkout = AutomationCheckout("isolated-worktree", "origin/main", "fetch")
+    renderer = AutomationSkillRenderer(_skill(), AutomationPolicy(), checkout)
     task = AutomationTask(
         "github",
         "Fix it",
@@ -152,13 +154,24 @@ def test_pi_runner_renders_isolated_checkout_contract() -> None:
         "target/repo",
         contract=_contract(),
     )
+    settings = PiExecutionSettings(
+        session_id="session-id",
+        name="session-name",
+        timeout_seconds=7200,
+    )
 
-    runner.run(_admitted(task))
+    prompt = renderer.render(
+        _admitted(task),
+        False,
+        settings,
+        TargetWorkspace(Path("/workspaces/task"), "abc123"),
+    )
 
-    assert "TARGET_CHECKOUT_MODE: isolated-worktree" in client.prompt
-    assert "TARGET_BASE_REF: origin/main" in client.prompt
-    assert "TARGET_BASE_SHA: abc123" in client.prompt
-    assert "TARGET_REFRESH: fetch" in client.prompt
+    assert "TARGET_CHECKOUT_MODE: isolated-worktree" in prompt
+    assert "TARGET_BASE_REF: origin/main" in prompt
+    assert "TARGET_BASE_SHA: abc123" in prompt
+    assert "TARGET_REFRESH: fetch" in prompt
+    assert "TARGET_WORKSPACE_PATH: /workspaces/task" in prompt
 
 
 def test_same_repository_task_renders_short_closing_reference() -> None:

--- a/tests/adapters/test_target_checkout.py
+++ b/tests/adapters/test_target_checkout.py
@@ -1,12 +1,15 @@
+import subprocess
 from pathlib import Path
 
 import pytest
 
-from groundskeeper.adapters.process import CommandResult
+from groundskeeper.adapters.process import CommandResult, ProcessClient
 from groundskeeper.adapters.target_checkout import (
     TargetCheckoutError,
+    prepare_target_checkout,
     validate_target_checkout,
 )
+from groundskeeper.domain.config import AutomationCheckout
 
 
 class FakeProcess:
@@ -74,3 +77,183 @@ def test_missing_or_malformed_origin_is_rejected(
 
     with pytest.raises(TargetCheckoutError):
         validate_target_checkout(process, Path("/repo"), "example/widgets")
+
+
+def test_isolated_checkout_requires_resolved_base_without_touching_donor() -> None:
+    process = FakeProcess(
+        [
+            (0, "true\n", ""),
+            (0, "git@github.com:Example/Widgets.git\n", ""),
+            (0, "abc123\n", ""),
+        ]
+    )
+
+    base_sha = validate_target_checkout(
+        process,
+        Path("/repo"),
+        "example/widgets",
+        AutomationCheckout("isolated-worktree", "origin/main", "none"),
+    )
+
+    assert base_sha == "abc123"
+    assert process.calls == [
+        ("git", "rev-parse", "--is-inside-work-tree"),
+        ("git", "remote", "get-url", "origin"),
+        (
+            "git",
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            "--end-of-options",
+            "origin/main^{commit}",
+        ),
+    ]
+    assert all("status" not in call for call in process.calls)
+
+
+def test_live_isolated_checkout_fetches_before_resolving_base() -> None:
+    process = FakeProcess(
+        [
+            (0, "true\n", ""),
+            (0, "git@github.com:Example/Widgets.git\n", ""),
+            (0, "", ""),
+            (0, "abc123\n", ""),
+        ]
+    )
+
+    base_sha = prepare_target_checkout(
+        process,
+        Path("/repo"),
+        "example/widgets",
+        AutomationCheckout("isolated-worktree", "origin/main", "fetch"),
+    )
+
+    assert base_sha == "abc123"
+    assert process.calls[-2:] == [
+        (
+            "git",
+            "fetch",
+            "--no-tags",
+            "origin",
+            "refs/heads/main:refs/remotes/origin/main",
+        ),
+        (
+            "git",
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            "--end-of-options",
+            "origin/main^{commit}",
+        ),
+    ]
+
+
+def test_live_isolated_checkout_stops_when_fetch_fails() -> None:
+    process = FakeProcess(
+        [
+            (0, "true\n", ""),
+            (0, "git@github.com:Example/Widgets.git\n", ""),
+            (1, "", "offline"),
+        ]
+    )
+
+    with pytest.raises(TargetCheckoutError, match="refresh failed"):
+        prepare_target_checkout(
+            process,
+            Path("/repo"),
+            "example/widgets",
+            AutomationCheckout("isolated-worktree", "origin/main", "fetch"),
+        )
+
+    assert len(process.calls) == 3
+
+
+def test_live_refresh_preserves_dirty_donor_worktree(tmp_path: Path) -> None:
+    remote = tmp_path / "remote.git"
+    seed = tmp_path / "seed"
+    donor = tmp_path / "donor"
+    subprocess.run(["git", "init", "--bare", "-q", remote], check=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", seed], check=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(remote)], cwd=seed, check=True
+    )
+    (seed / "tracked.txt").write_text("one\n")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=seed, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Groundskeeper Test",
+            "-c",
+            "user.email=groundskeeper@example.com",
+            "commit",
+            "-qm",
+            "one",
+        ],
+        cwd=seed,
+        check=True,
+    )
+    subprocess.run(["git", "push", "-q", "-u", "origin", "main"], cwd=seed, check=True)
+    subprocess.run(["git", "clone", "-q", "-b", "main", remote, donor], check=True)
+    donor_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=donor,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    (donor / "unrelated.txt").write_text("preserve me\n")
+    (seed / "tracked.txt").write_text("two\n")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=seed, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Groundskeeper Test",
+            "-c",
+            "user.email=groundskeeper@example.com",
+            "commit",
+            "-qm",
+            "two",
+        ],
+        cwd=seed,
+        check=True,
+    )
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=seed, check=True)
+    remote_head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=seed,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    class LocalRemoteProcess(ProcessClient):
+        def run(
+            self, argv: tuple[str, ...], cwd: Path, timeout: int | None = None
+        ) -> CommandResult:
+            if argv == ("git", "remote", "get-url", "origin"):
+                return CommandResult(
+                    argv, cwd, 0, "git@github.com:example/widgets.git\n", ""
+                )
+            return super().run(argv, cwd, timeout)
+
+    base_sha = prepare_target_checkout(
+        LocalRemoteProcess(),
+        donor,
+        "example/widgets",
+        AutomationCheckout("isolated-worktree", "origin/main", "fetch"),
+    )
+
+    assert base_sha == remote_head
+    assert (
+        subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=donor,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        == donor_head
+    )
+    assert (donor / "unrelated.txt").read_text() == "preserve me\n"

--- a/tests/adapters/test_target_checkout.py
+++ b/tests/adapters/test_target_checkout.py
@@ -138,7 +138,7 @@ def test_live_isolated_checkout_fetches_before_resolving_base() -> None:
             "fetch",
             "--no-tags",
             "origin",
-            "refs/heads/main:refs/remotes/origin/main",
+            "+refs/heads/main:refs/remotes/origin/main",
         ),
         (
             "git",

--- a/tests/adapters/test_target_checkout.py
+++ b/tests/adapters/test_target_checkout.py
@@ -6,9 +6,12 @@ import pytest
 from groundskeeper.adapters.process import CommandResult, ProcessClient
 from groundskeeper.adapters.target_checkout import (
     TargetCheckoutError,
+    TargetCheckoutManager,
     prepare_target_checkout,
+    target_checkout_common_dir,
     validate_target_checkout,
 )
+from groundskeeper.domain.automation import AutomationTask, GitHubIssueIdentity
 from groundskeeper.domain.config import AutomationCheckout
 
 
@@ -168,6 +171,29 @@ def test_live_isolated_checkout_stops_when_fetch_fails() -> None:
     assert len(process.calls) == 3
 
 
+def test_workspace_rejects_task_for_different_target() -> None:
+    manager = TargetCheckoutManager(
+        ProcessClient(),
+        Path("/repo"),
+        "example/widgets",
+        AutomationCheckout(),
+        None,
+        Path("/state"),
+    )
+    task = AutomationTask(
+        "github",
+        "Do work",
+        "Acceptance",
+        "https://github.com/source/queue/issues/7",
+        "alex",
+        GitHubIssueIdentity("source/queue", 7),
+        "other/repository",
+    )
+
+    with pytest.raises(TargetCheckoutError, match="does not match"):
+        manager.workspace_for(task)
+
+
 def test_live_refresh_preserves_dirty_donor_worktree(tmp_path: Path) -> None:
     remote = tmp_path / "remote.git"
     seed = tmp_path / "seed"
@@ -238,14 +264,49 @@ def test_live_refresh_preserves_dirty_donor_worktree(tmp_path: Path) -> None:
                 )
             return super().run(argv, cwd, timeout)
 
+    process = LocalRemoteProcess()
+    checkout = AutomationCheckout("isolated-worktree", "origin/main", "fetch")
     base_sha = prepare_target_checkout(
-        LocalRemoteProcess(),
+        process,
         donor,
         "example/widgets",
-        AutomationCheckout("isolated-worktree", "origin/main", "fetch"),
+        checkout,
     )
+    task = AutomationTask(
+        "github",
+        "Do work",
+        "Acceptance",
+        "https://github.com/source/queue/issues/7",
+        "alex",
+        GitHubIssueIdentity("source/queue", 7),
+        "example/widgets",
+    )
+    manager = TargetCheckoutManager(
+        process,
+        donor,
+        "example/widgets",
+        checkout,
+        base_sha,
+        tmp_path / "state",
+    )
+    workspace = manager.workspace_for(task)
 
     assert base_sha == remote_head
+    assert workspace.base_sha == remote_head
+    assert workspace.path != donor
+    assert target_checkout_common_dir(process, donor) == target_checkout_common_dir(
+        process, workspace.path
+    )
+    assert (
+        subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=workspace.path,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        == remote_head
+    )
     assert (
         subprocess.run(
             ["git", "rev-parse", "HEAD"],
@@ -257,3 +318,63 @@ def test_live_refresh_preserves_dirty_donor_worktree(tmp_path: Path) -> None:
         == donor_head
     )
     assert (donor / "unrelated.txt").read_text() == "preserve me\n"
+
+    (seed / "tracked.txt").write_text("three\n")
+    subprocess.run(["git", "add", "tracked.txt"], cwd=seed, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Groundskeeper Test",
+            "-c",
+            "user.email=groundskeeper@example.com",
+            "commit",
+            "-qm",
+            "three",
+        ],
+        cwd=seed,
+        check=True,
+    )
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=seed, check=True)
+    newer_base = prepare_target_checkout(
+        process,
+        donor,
+        "example/widgets",
+        checkout,
+    )
+    recovered = TargetCheckoutManager(
+        process,
+        donor,
+        "example/widgets",
+        checkout,
+        newer_base,
+        tmp_path / "state",
+    ).workspace_for(task)
+
+    assert newer_base != remote_head
+    assert recovered.path == workspace.path
+    assert recovered.base_sha == remote_head
+
+    pinned_ref = subprocess.run(
+        [
+            "git",
+            "for-each-ref",
+            "--format=%(refname)",
+            "refs/groundskeeper/bases",
+        ],
+        cwd=donor,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(["git", "update-ref", "-d", pinned_ref], cwd=donor, check=True)
+
+    with pytest.raises(TargetCheckoutError, match="without its immutable base pin"):
+        TargetCheckoutManager(
+            process,
+            donor,
+            "example/widgets",
+            checkout,
+            newer_base,
+            tmp_path / "state",
+        ).workspace_for(task)

--- a/tests/cli/test_cli_automation.py
+++ b/tests/cli/test_cli_automation.py
@@ -7,7 +7,11 @@ import yaml
 from click.testing import CliRunner
 
 from groundskeeper.adapters.tick_lock import TickAlreadyRunningError
-from groundskeeper.cli.main import _automation_lock_path, cli
+from groundskeeper.cli.main import (
+    _automation_lock_path,
+    _automation_target_lock_path,
+    cli,
+)
 from groundskeeper.domain.automation import (
     AutomationTask,
     GitHubIssueIdentity,
@@ -26,6 +30,10 @@ def _accept_target_checkout(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "groundskeeper.cli.main.prepare_target_checkout",
         lambda process, repository_path, expected_repository, checkout: None,
+    )
+    monkeypatch.setattr(
+        "groundskeeper.cli.main.target_checkout_common_dir",
+        lambda process, repository_path: repository_path / ".git",
     )
 
 
@@ -125,6 +133,13 @@ def test_repository_locks_are_host_scoped_and_identity_stable(
     )[0]
     assert _automation_lock_path(queue_a) == _automation_lock_path(queue_b)
     assert _automation_lock_path(queue_a) != _automation_lock_path(other_repo)
+    common_dir = tmp_path / "git-common"
+    assert _automation_target_lock_path(
+        queue_a, common_dir
+    ) == _automation_target_lock_path(other_repo, common_dir)
+    assert _automation_lock_path(queue_a) != _automation_target_lock_path(
+        queue_a, common_dir
+    )
     assert (
         _automation_lock_path(queue_a).parent
         == tmp_path / "state" / "groundskeeper" / "locks"
@@ -337,6 +352,28 @@ def test_unsupported_host_fails_before_tracker_mutation(
     mock_tick.assert_not_called()  # type: ignore[attr-defined]
 
 
+@patch("groundskeeper.cli.main.prepare_target_checkout")
+@patch("groundskeeper.cli.main.PiClient.is_available", return_value=False)
+@patch("groundskeeper.cli.main.AutomationService.tick")
+def test_missing_pi_fails_before_target_refresh(
+    mock_tick: object,
+    mock_available: object,
+    mock_prepare: object,
+    tmp_path: Path,
+) -> None:
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path(".groundskeeper").mkdir(exist_ok=True)
+        Path(".groundskeeper/config.yml").write_text(CONFIG)
+        result = runner.invoke(cli, ["automation", "tick", "daily-dev", "--json"])
+
+    assert result.exit_code == 2
+    assert "Pi CLI not found" in json.loads(result.output)["data"]["error"]
+    mock_available.assert_called_once()  # type: ignore[attr-defined]
+    mock_prepare.assert_not_called()  # type: ignore[attr-defined]
+    mock_tick.assert_not_called()  # type: ignore[attr-defined]
+
+
 def test_text_errors_use_documented_exit_code(tmp_path: Path) -> None:
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=tmp_path):
@@ -405,6 +442,24 @@ def test_strict_config_errors_offer_copyable_corrections(
         result = runner.invoke(cli, ["automation", "validate", "daily-dev", "--json"])
     assert result.exit_code == 2
     assert f"Use '{replacement}'." in json.loads(result.output)["data"]["error"]
+
+
+def test_explicit_null_checkout_fails_closed_in_cli_validation(tmp_path: Path) -> None:
+    invalid_config = CONFIG.replace(
+        "      repository-path: /tmp",
+        "      repository-path: /tmp\n      checkout:",
+    )
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path(".groundskeeper").mkdir(exist_ok=True)
+        Path(".groundskeeper/config.yml").write_text(invalid_config)
+        result = runner.invoke(cli, ["automation", "validate", "daily-dev", "--json"])
+
+    assert result.exit_code == 2
+    assert (
+        "target.checkout must be a mapping"
+        in json.loads(result.output)["data"]["error"]
+    )
 
 
 def test_malformed_config_json_envelope(tmp_path: Path) -> None:

--- a/tests/cli/test_cli_automation.py
+++ b/tests/cli/test_cli_automation.py
@@ -140,6 +140,7 @@ def test_repository_locks_are_host_scoped_and_identity_stable(
     assert _automation_lock_path(queue_a) != _automation_target_lock_path(
         queue_a, common_dir
     )
+    assert _automation_lock_path(queue_a).name.startswith("repository-")
     assert (
         _automation_lock_path(queue_a).parent
         == tmp_path / "state" / "groundskeeper" / "locks"

--- a/tests/cli/test_cli_automation.py
+++ b/tests/cli/test_cli_automation.py
@@ -21,7 +21,11 @@ from groundskeeper.domain.config import get_automations
 def _accept_target_checkout(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "groundskeeper.cli.main.validate_target_checkout",
-        lambda process, repository_path, expected_repository: None,
+        lambda process, repository_path, expected_repository, checkout: None,
+    )
+    monkeypatch.setattr(
+        "groundskeeper.cli.main.prepare_target_checkout",
+        lambda process, repository_path, expected_repository, checkout: None,
     )
 
 
@@ -81,6 +85,11 @@ def test_automation_list_json(tmp_path: Path) -> None:
                     "target": {
                         "repository": "me/dots",
                         "repository_path": str(Path("/tmp").resolve()),
+                        "checkout": {
+                            "mode": "existing",
+                            "base_ref": None,
+                            "refresh": "none",
+                        },
                     },
                     "runner": {
                         "type": "pi",
@@ -161,6 +170,11 @@ def test_automation_show_and_validate_use_versioned_envelopes(
                 "target": {
                     "repository": "me/dots",
                     "repository_path": str(Path("/tmp").resolve()),
+                    "checkout": {
+                        "mode": "existing",
+                        "base_ref": None,
+                        "refresh": "none",
+                    },
                 },
                 "runner": {
                     "type": "pi",
@@ -211,6 +225,11 @@ def test_inspect_full_versioned_payload(mock_tracker: object, tmp_path: Path) ->
             "target": {
                 "repository": "me/dots",
                 "repository_path": str(Path("/tmp").resolve()),
+                "checkout": {
+                    "mode": "existing",
+                    "base_ref": None,
+                    "refresh": "none",
+                },
             },
             "tasks": [],
         },
@@ -271,6 +290,11 @@ def test_tick_dry_run_omits_issue_body_from_json(
             "target": {
                 "repository": "me/dots",
                 "repository_path": str(Path("/tmp").resolve()),
+                "checkout": {
+                    "mode": "existing",
+                    "base_ref": None,
+                    "refresh": "none",
+                },
             },
             "task": {
                 "id": "7",

--- a/tests/domain/test_automation_config.py
+++ b/tests/domain/test_automation_config.py
@@ -68,6 +68,7 @@ def test_parses_isolated_worktree_checkout_policy() -> None:
     ("checkout", "message"),
     [
         ({}, "checkout.mode"),
+        (None, "target.checkout must be a mapping"),
         ({"mode": "unknown"}, "checkout.mode"),
         ({"mode": "existing", "base-ref": "origin/main"}, "only valid"),
         ({"mode": "isolated-worktree"}, "checkout.base-ref"),
@@ -94,7 +95,7 @@ def test_parses_isolated_worktree_checkout_policy() -> None:
     ],
 )
 def test_rejects_invalid_checkout_policy(
-    checkout: dict[str, object], message: str
+    checkout: dict[str, object] | None, message: str
 ) -> None:
     config = _valid_automation_config()
     config["automations"]["daily"]["target"]["checkout"] = checkout  # type: ignore[index]

--- a/tests/domain/test_automation_config.py
+++ b/tests/domain/test_automation_config.py
@@ -40,10 +40,67 @@ def test_parses_explicit_source_and_target_automation() -> None:
     assert item.source.deferred_label == "factory:deferred"
     assert item.target.repository == "me/dots"
     assert item.target.repository_path == Path("/tmp/dots").resolve()
+    assert item.target.checkout.mode == "existing"
+    assert item.target.checkout.base_ref is None
+    assert item.target.checkout.refresh == "none"
     assert item.runner.skill == "issue-implementation"
     assert item.runner.approval == "allow"
     assert item.runner.session == "deterministic"
     assert item.runner.timeout_seconds == 7200
+
+
+def test_parses_isolated_worktree_checkout_policy() -> None:
+    config = _valid_automation_config()
+    config["automations"]["daily"]["target"]["checkout"] = {  # type: ignore[index]
+        "mode": "isolated-worktree",
+        "base-ref": "origin/main",
+        "refresh": "fetch",
+    }
+
+    checkout = get_automations(config)[0].target.checkout
+
+    assert checkout.mode == "isolated-worktree"
+    assert checkout.base_ref == "origin/main"
+    assert checkout.refresh == "fetch"
+
+
+@pytest.mark.parametrize(
+    ("checkout", "message"),
+    [
+        ({}, "checkout.mode"),
+        ({"mode": "unknown"}, "checkout.mode"),
+        ({"mode": "existing", "base-ref": "origin/main"}, "only valid"),
+        ({"mode": "isolated-worktree"}, "checkout.base-ref"),
+        (
+            {"mode": "isolated-worktree", "base-ref": "main", "refresh": "fetch"},
+            "origin/",
+        ),
+        (
+            {
+                "mode": "isolated-worktree",
+                "base-ref": "origin/main",
+                "refresh": "sometimes",
+            },
+            "checkout.refresh",
+        ),
+        (
+            {
+                "mode": "isolated-worktree",
+                "base-ref": "origin/main",
+                "unexpected": True,
+            },
+            "checkout.*unknown key",
+        ),
+    ],
+)
+def test_rejects_invalid_checkout_policy(
+    checkout: dict[str, object], message: str
+) -> None:
+    config = _valid_automation_config()
+    config["automations"]["daily"]["target"]["checkout"] = checkout  # type: ignore[index]
+
+    with pytest.raises(ConfigError, match=message):
+        get_automations(config)
 
 
 @pytest.mark.parametrize("missing", ["source", "target"])
@@ -107,7 +164,7 @@ def test_rejects_non_positive_pi_timeout() -> None:
     [
         ("entry", "unexpected", "automations.daily"),
         ("source", "repo", "automations.daily.source"),
-        ("target", "checkout", "automations.daily.target"),
+        ("target", "checkout-policy", "automations.daily.target"),
         ("runner", "timeout_seconds", "automations.daily.runner"),
         ("policy", "concurency", "automations.daily.policy"),
         ("labels", "done", "automations.daily.source.labels"),

--- a/tests/e2e/test_e2e_commands.py
+++ b/tests/e2e/test_e2e_commands.py
@@ -324,6 +324,54 @@ class TestAutomationE2E:
         assert validated_automation["target"]["repository"] == "target/repo"
         assert json.loads(validated.stdout)["version"] == 2
 
+    def test_validate_resolves_isolated_checkout_base_through_real_process(
+        self, tmp_path: Path
+    ) -> None:
+        repo, env = _factory_repo(tmp_path, "[]")
+        (repo / "tracked.txt").write_text("base\n")
+        subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True)
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=Groundskeeper Test",
+                "-c",
+                "user.email=groundskeeper@example.com",
+                "commit",
+                "-qm",
+                "base",
+            ],
+            cwd=repo,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "update-ref", "refs/remotes/origin/main", "HEAD"],
+            cwd=repo,
+            check=True,
+        )
+        config_path = repo / ".groundskeeper/config.yml"
+        config = yaml.safe_load(config_path.read_text())
+        config["automations"]["daily"]["target"]["checkout"] = {
+            "mode": "isolated-worktree",
+            "base-ref": "origin/main",
+            "refresh": "none",
+        }
+        config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+
+        validated = run_gk(
+            "automation", "validate", "daily", "--json", cwd=repo, env=env
+        )
+
+        assert validated.returncode == 0
+        checkout = json.loads(validated.stdout)["data"]["automations"][0]["target"][
+            "checkout"
+        ]
+        assert checkout == {
+            "mode": "isolated-worktree",
+            "base_ref": "origin/main",
+            "refresh": "none",
+        }
+
     def test_dry_run_is_compact_and_does_not_launch_pi_or_write_state(
         self, tmp_path: Path
     ) -> None:

--- a/tests/e2e/test_e2e_commands.py
+++ b/tests/e2e/test_e2e_commands.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -238,6 +239,7 @@ def _deferred_factory_repo(tmp_path: Path) -> tuple[Path, dict[str, str], Path, 
     pi = binary_dir / "pi"
     pi.write_text(
         "#!/bin/sh\n"
+        f"echo \"cwd=$(pwd)\" >> '{pi_log}'\n"
         f"echo \"$*\" >> '{pi_log}'\n"
         f"COUNT=$(cat '{attempts}')\nCOUNT=$((COUNT + 1))\necho $COUNT > '{attempts}'\n"
         f"if [ \"$COUNT\" -lt 3 ]; then echo 'Codex usage limit reached; retry later' >&2; exit 1; fi\n"
@@ -371,6 +373,174 @@ class TestAutomationE2E:
             "base_ref": "origin/main",
             "refresh": "none",
         }
+
+    def test_live_tick_fetches_immutable_base_without_modifying_dirty_donor(
+        self, tmp_path: Path
+    ) -> None:
+        repo, env, _, pi_log = _deferred_factory_repo(tmp_path)
+        state_home = tmp_path / "state"
+        env["GROUNDSKEEPER_STATE_HOME"] = str(state_home)
+        real_git = shutil.which("git")
+        assert real_git is not None
+        remote = tmp_path / "remote.git"
+        updater = tmp_path / "updater"
+        subprocess.run([real_git, "init", "--bare", "-q", remote], check=True)
+        subprocess.run(
+            [real_git, "remote", "set-url", "origin", remote], cwd=repo, check=True
+        )
+        subprocess.run([real_git, "switch", "-c", "main"], cwd=repo, check=True)
+        (repo / "tracked.txt").write_text("donor base\n")
+        subprocess.run([real_git, "add", "tracked.txt"], cwd=repo, check=True)
+        subprocess.run(
+            [
+                real_git,
+                "-c",
+                "user.name=Groundskeeper Test",
+                "-c",
+                "user.email=groundskeeper@example.com",
+                "commit",
+                "-qm",
+                "donor base",
+            ],
+            cwd=repo,
+            check=True,
+        )
+        subprocess.run(
+            [real_git, "push", "-q", "-u", "origin", "main"], cwd=repo, check=True
+        )
+        donor_head = subprocess.run(
+            [real_git, "rev-parse", "HEAD"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        (repo / "unrelated.txt").write_text("preserve me\n")
+
+        subprocess.run(
+            [real_git, "clone", "-q", "-b", "main", remote, updater], check=True
+        )
+        (updater / "tracked.txt").write_text("remote advance\n")
+        subprocess.run([real_git, "add", "tracked.txt"], cwd=updater, check=True)
+        subprocess.run(
+            [
+                real_git,
+                "-c",
+                "user.name=Groundskeeper Test",
+                "-c",
+                "user.email=groundskeeper@example.com",
+                "commit",
+                "-qm",
+                "remote advance",
+            ],
+            cwd=updater,
+            check=True,
+        )
+        subprocess.run(
+            [real_git, "push", "-q", "origin", "main"], cwd=updater, check=True
+        )
+        remote_head = subprocess.run(
+            [real_git, "rev-parse", "HEAD"],
+            cwd=updater,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        config_path = repo / ".groundskeeper/config.yml"
+        config = yaml.safe_load(config_path.read_text())
+        config["automations"]["daily"]["target"]["checkout"] = {
+            "mode": "isolated-worktree",
+            "base-ref": "origin/main",
+            "refresh": "fetch",
+        }
+        config_path.write_text(yaml.safe_dump(config, sort_keys=False))
+
+        binary_dir = tmp_path / "bin"
+        git_wrapper = binary_dir / "git"
+        git_wrapper.write_text(
+            "#!/bin/sh\n"
+            'if [ "$*" = "remote get-url origin" ]; then\n'
+            "  printf '%s\\n' 'git@github.com:target/repo.git'\n"
+            "  exit 0\n"
+            "fi\n"
+            f"exec '{real_git}' \"$@\"\n"
+        )
+        git_wrapper.chmod(0o755)
+
+        first = run_gk("automation", "tick", "daily", "--json", cwd=repo, env=env)
+
+        (updater / "tracked.txt").write_text("remote moves again\n")
+        subprocess.run([real_git, "add", "tracked.txt"], cwd=updater, check=True)
+        subprocess.run(
+            [
+                real_git,
+                "-c",
+                "user.name=Groundskeeper Test",
+                "-c",
+                "user.email=groundskeeper@example.com",
+                "commit",
+                "-qm",
+                "remote moves again",
+            ],
+            cwd=updater,
+            check=True,
+        )
+        subprocess.run(
+            [real_git, "push", "-q", "origin", "main"], cwd=updater, check=True
+        )
+        newer_remote_head = subprocess.run(
+            [real_git, "rev-parse", "HEAD"],
+            cwd=updater,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+        second = run_gk("automation", "tick", "daily", "--json", cwd=repo, env=env)
+        third = run_gk("automation", "tick", "daily", "--json", cwd=repo, env=env)
+
+        assert first.returncode == second.returncode == third.returncode == 0
+        assert [
+            json.loads(first.stdout)["status"],
+            json.loads(second.stdout)["status"],
+            json.loads(third.stdout)["status"],
+        ] == ["deferred", "deferred", "review"]
+        pi_calls = pi_log.read_text().splitlines()
+        workspaces = {
+            line.removeprefix("cwd=") for line in pi_calls if line.startswith("cwd=")
+        }
+        assert len(workspaces) == 1
+        workspace = Path(workspaces.pop())
+        assert workspace != repo
+        assert workspace.is_relative_to(state_home / "groundskeeper" / "worktrees")
+        prompt_log = "\n".join(pi_calls)
+        assert prompt_log.count("TARGET_CHECKOUT_MODE: isolated-worktree") == 3
+        assert prompt_log.count("TARGET_BASE_REF: origin/main") == 3
+        assert prompt_log.count(f"TARGET_BASE_SHA: {remote_head}") == 3
+        assert newer_remote_head not in prompt_log
+        assert (
+            subprocess.run(
+                [real_git, "rev-parse", "HEAD"],
+                cwd=workspace,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            == remote_head
+        )
+        assert (
+            subprocess.run(
+                [real_git, "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            == donor_head
+        )
+        assert (repo / "tracked.txt").read_text() == "donor base\n"
+        assert (repo / "unrelated.txt").read_text() == "preserve me\n"
 
     def test_dry_run_is_compact_and_does_not_launch_pi_or_write_state(
         self, tmp_path: Path


### PR DESCRIPTION
Factory workers need a clean task base, but the configured repository path may be a developer’s dirty canonical checkout. Treating donor dirtiness as task state either blocks valid work or risks mutating unrelated changes.

This adds an optional typed checkout policy:

```yaml
checkout:
  mode: isolated-worktree
  base-ref: origin/main
  refresh: fetch
```

Groundskeeper validates the donor and origin, optionally refreshes the exact `origin/*` branch before claim, and freezes its commit. After claim it pins that original task base in Git, creates a deterministic task branch/worktree, and runs Pi there. Deferred or running recovery reuses the same worktree and base even if the configured ref advances.

The donor working tree is never inspected or modified. Source admission and target Git resources use separate host locks; linked donor worktrees coordinate through their shared Git common directory. Explicit malformed checkout configuration fails closed, while omitting `checkout` preserves the existing cwd behavior.

## Review focus

The main ownership seam is the target checkout module: donor validation and refresh, immutable base pinning, deterministic worktree recovery, and Pi cwd all live there. Skills retain workflow instructions but no longer implement Git workspace lifecycle.

Task worktrees are deliberately retained for draft-PR review and recovery. Automatic lock-protected garbage collection is documented as future work.

## Evidence

The full local suite passes with 371 tests and 88% coverage, strict documentation builds, and all 38 installed-CLI E2E tests pass. The process-level recovery test advances the remote between three ticks and demonstrates an unchanged dirty donor, one isolated Pi cwd, and the same original base throughout recovery.
