### PR TITLE
Add managed scheduled automation runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,31 @@ issue to `factory:deferred` with an actionable comment and are resumed on the
 next tick. Authentication, model configuration, policy, timeout, and ordinary
 worker failures move it to `factory:blocked`. The breaking source/target JSON
 shape uses envelope version `2`, and dry-run output deliberately omits
-issue bodies. Set a scheduler's working directory to the repository containing
-`.groundskeeper/config.yml`, or pass `gk automation --config PATH ...`.
+issue bodies.
+
+For unattended execution, point launchd, systemd, or cron at the installed
+Groundskeeper command rather than a script inside the configuration checkout:
+
+```bash
+gk automation \
+  --config .groundskeeper/config.yml \
+  run-scheduled \
+  --schedule-id personal-factory \
+  --source-repository-path /Users/you/src/factory-config \
+  --source-ref origin/main \
+  --source-refresh fetch \
+  --daily-attempt-limit 5 \
+  --rotation daily \
+  --json
+```
+
+`run-scheduled` fetches and pins the configured ref, then loads configuration
+and local skills from a clean detached worktree under Groundskeeper's host
+state. The donor checkout may be dirty or on another branch and is never
+cleaned, reset, stashed, or used as the execution directory. Groundskeeper owns
+the bounded source worktree, crash-safe daily reservations, ordering, and tick
+lifecycle; the host adapter owns only calendar timing, secret injection, and
+runtime-specific launchers.
 
 The lifecycle is deliberately small and label-backed:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,6 +131,34 @@ prompt. `merge: never` is an accepted-result contract, not a credential sandbox.
 Host-state locking coordinates source admission and target workspaces on one
 machine and does not provide distributed locking.
 
+### Scheduled local automation
+
+```text
+host adapter (launchd, systemd, cron)
+  → installed `gk automation ... run-scheduled`
+  → acquire the named schedule lock
+  → acquire the execution-source repository lock
+  → optionally fetch the configured origin branch without touching donor files
+  → resolve and pin one commit
+  → create, advance, or validate one clean detached pinned worktree
+  → resolve the repository-relative config and local skills inside that snapshot
+  → validate every selected automation before quota state is opened
+  → rotate selected automations and run bounded ticks under one daily ledger
+  → emit one versioned JSON schedule result
+```
+
+The execution-source adapter owns Git refresh, commit resolution, and the
+bounded reusable configuration worktree. The scheduler application module owns
+lock ordering, repository-wide source-lease duration, preflight ordering, result
+aggregation, and daily reservation policy; its file-backed ledger adapter owns
+strict, locked persistence. Schedules using different refs from the same Git
+common directory serialize because fetch and worktree administration mutate
+shared repository state. The existing automation lifecycle continues to own
+tracker reconciliation and target task worktrees. A host adapter owns only
+calendar timing, environment/secrets, and runtime-specific executable wiring.
+The developer checkout is a donor for Git object access, not an execution
+directory or cleanliness authority.
+
 ## CI Generation Flow
 
 ```

--- a/docs/config-and-skills.md
+++ b/docs/config-and-skills.md
@@ -112,6 +112,36 @@ delete its `groundskeeper/task-*` branch and `refs/groundskeeper/bases/*` ref
 only after the task and pull request no longer need recovery. Automated,
 lock-protected retention policy remains future work.
 
+### Host scheduler execution source
+
+Use `gk automation ... run-scheduled` behind a host scheduler when automation
+configuration and local skills are versioned in Git. The command takes an
+explicit donor repository, ref, refresh policy, schedule identity, and daily
+attempt limit. The config path remains the normal `automation --config` option,
+but must be repository-relative:
+
+```bash
+gk automation \
+  --config .groundskeeper/config.work.yml \
+  run-scheduled discord-dev \
+  --schedule-id work-factory \
+  --source-repository-path /Users/you/src/dots \
+  --source-ref origin/main \
+  --source-refresh fetch \
+  --daily-attempt-limit 1 \
+  --rotation fixed \
+  --json
+```
+
+Groundskeeper executes the config and local skills from a managed detached
+snapshot of the resolved commit. It does not execute repository scripts or read
+working-tree configuration from the donor. A dirty donor therefore does not
+block a scheduled run or override reviewed configuration. Paths that are
+absolute or escape the snapshot are rejected, as are external `--skill-path`
+directories and local-skill symlinks that resolve outside the snapshot. The
+operating-system schedule, secret injection, and runtime-specific Pi wrapper
+remain host policy and are not part of the automation YAML schema.
+
 Pi runners accept optional positive `timeout-seconds` (default: `7200`) for
 long-running development work. GitHub CLI operations use a fixed 30-second
 timeout. Before dispatch and after any worker return, Groundskeeper reconciles the exact

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -27,6 +27,14 @@ gk automation show NAME [--json]
 gk automation validate [NAME] [--json]
 gk automation inspect NAME [--json]
 gk automation tick NAME [--dry-run] [--json]
+gk automation --config RELATIVE_PATH run-scheduled [NAME ...] \
+  --schedule-id ID \
+  --source-repository-path PATH \
+  --daily-attempt-limit N \
+  [--source-ref origin/main] \
+  [--source-refresh fetch|none] \
+  [--rotation daily|fixed] \
+  [--json]
 ```
 
 `list` and `show` inspect configured local automations. `inspect` reads tracker
@@ -63,6 +71,31 @@ profiles can substitute their profile wrapper, such as `pih`. Pi automation
 requires POSIX process-group isolation; validation and live ticks reject
 unsupported hosts before tracker access, issue claim, or worker startup rather
 than risk descendants surviving after lock release.
+
+`run-scheduled` is the stable installed-CLI entry point for launchd, systemd,
+cron, or another host scheduler. Its `--config` path must be relative to the
+execution-source repository. Groundskeeper locks the source, optionally fetches
+the exact configured `origin/*` branch, resolves one commit, and materializes a
+clean detached snapshot under its host state directory. Configuration and local
+skills are loaded only from that pinned snapshot. The donor checkout
+may be on another branch or contain tracked and untracked changes; scheduled
+execution never checks, stashes, resets, checks out, cleans, or executes files
+from that working tree. External `--skill-path` directories and snapshot
+symlinks that resolve outside the snapshot are rejected.
+
+When no names are supplied, `run-scheduled` uses all automations in declaration
+order. `daily` rotation changes the first automation by local calendar day;
+`fixed` preserves declaration order. Groundskeeper reserves quota before every
+mutating tick and refunds only a proven `no-work` or `not-claimed` result, so a
+crash cannot fail open. The schedule ID owns a non-overlap lock and strict daily
+ledger under the Groundskeeper state root. Preflight validates the pinned
+config, skills, Pi, and target checkouts before opening that ledger. The JSON
+result includes the execution ref, pinned commit, managed workspace, quota
+state, and each tick result.
+
+The host adapter remains outside Groundskeeper: it chooses when to invoke the
+command and supplies secrets or a private Pi launcher. It should execute the
+installed `gk`, not a script from the donor repository.
 
 Pi runner configuration accepts optional `timeout-seconds` (default: 7,200) for
 long-running tasks. GitHub CLI calls use a fixed 30-second timeout. Groundskeeper

--- a/groundskeeper/adapters/execution_source.py
+++ b/groundskeeper/adapters/execution_source.py
@@ -1,0 +1,264 @@
+"""Immutable configuration snapshots for host-local scheduled automation."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+from groundskeeper.adapters.process import ProcessClient
+
+GIT_OPERATION_TIMEOUT_SECONDS = 30
+
+
+class ExecutionSourceError(RuntimeError):
+    """The configured scheduler execution source cannot be used safely."""
+
+
+@dataclass(frozen=True)
+class ExecutionSource:
+    """One immutable repository snapshot used for a scheduled run."""
+
+    path: Path
+    commit: str
+
+
+def resolve_execution_path(snapshot: Path, configured: Path) -> Path:
+    """Resolve a repository-relative path without allowing snapshot escape."""
+    if configured.is_absolute():
+        raise ExecutionSourceError(
+            "scheduled config must be a relative path inside its execution snapshot"
+        )
+    resolved_snapshot = snapshot.resolve()
+    resolved = (resolved_snapshot / configured).resolve()
+    if not resolved.is_relative_to(resolved_snapshot):
+        raise ExecutionSourceError(
+            "scheduled config must be a relative path inside its execution snapshot"
+        )
+    return resolved
+
+
+def validate_execution_tree(snapshot: Path, tree: Path) -> None:
+    """Reject symlinks that let scheduled inputs escape their Git snapshot."""
+    if not tree.exists():
+        return
+    resolved_snapshot = snapshot.resolve()
+    candidates = [tree, *tree.rglob("*")]
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError as error:
+            raise ExecutionSourceError(
+                "scheduled input cannot be resolved inside its execution snapshot: "
+                f"{candidate}"
+            ) from error
+        if not resolved.is_relative_to(resolved_snapshot):
+            raise ExecutionSourceError(
+                "scheduled inputs must remain inside their execution snapshot: "
+                f"{candidate}"
+            )
+
+
+class ExecutionSourceManager:
+    """Refresh and materialize one bounded scheduler source worktree."""
+
+    def __init__(
+        self,
+        process: ProcessClient,
+        repository_path: Path,
+        ref: str,
+        refresh: str,
+        state_root: Path,
+    ) -> None:
+        self._process = process
+        self._repository_path = repository_path.resolve()
+        self._ref = ref
+        self._refresh = refresh
+        self._state_root = state_root
+
+    def prepare(self) -> ExecutionSource:
+        """Resolve the configured ref and return its clean detached snapshot."""
+        self._validate_donor()
+        if self._refresh == "fetch":
+            self._fetch_origin_ref()
+        elif self._refresh != "none":
+            raise ExecutionSourceError(
+                f"unsupported execution source refresh policy: {self._refresh}"
+            )
+        commit = self._resolve_commit()
+        common_dir = self.common_dir()
+        source_key = hashlib.sha256(f"{common_dir}\0{self._ref}".encode()).hexdigest()[
+            :16
+        ]
+        snapshot = (
+            self._state_root / "execution-sources" / source_key / "worktree"
+        ).resolve()
+        if snapshot.exists():
+            current = self._validate_snapshot(snapshot, common_dir)
+            if current != commit:
+                self._run_or_raise(
+                    ("git", "checkout", "--detach", commit),
+                    snapshot,
+                    "could not advance managed execution source",
+                )
+        else:
+            try:
+                snapshot.parent.mkdir(parents=True, exist_ok=True)
+            except OSError as error:
+                raise ExecutionSourceError(
+                    f"could not create execution source directory: {error}"
+                ) from error
+            self._run_or_raise(
+                ("git", "worktree", "add", "--detach", str(snapshot), commit),
+                self._repository_path,
+                "could not materialize execution source",
+            )
+        pinned = self._validate_snapshot(snapshot, common_dir)
+        if pinned != commit:
+            raise ExecutionSourceError(
+                f"managed execution source is not at its pinned commit: {snapshot}"
+            )
+        return ExecutionSource(snapshot, commit)
+
+    def common_dir(self) -> Path:
+        """Return the Git metadata directory shared by the source worktrees."""
+        result = self._process.run(
+            ("git", "rev-parse", "--git-common-dir"),
+            self._repository_path,
+            timeout=GIT_OPERATION_TIMEOUT_SECONDS,
+        )
+        if not result.success or not result.stdout.strip():
+            detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+            raise ExecutionSourceError(
+                f"could not identify execution source Git directory: {detail}"
+            )
+        value = Path(result.stdout.strip())
+        return (
+            value.resolve()
+            if value.is_absolute()
+            else (self._repository_path / value).resolve()
+        )
+
+    def _validate_donor(self) -> None:
+        result = self._process.run(
+            ("git", "rev-parse", "--is-inside-work-tree"),
+            self._repository_path,
+            timeout=GIT_OPERATION_TIMEOUT_SECONDS,
+        )
+        if not result.success or result.stdout.strip() != "true":
+            raise ExecutionSourceError(
+                "execution source repository path is not a Git worktree: "
+                f"{self._repository_path}"
+            )
+
+    def _fetch_origin_ref(self) -> None:
+        if not self._ref.startswith("origin/"):
+            raise ExecutionSourceError(
+                "execution source refresh 'fetch' requires an origin/* ref"
+            )
+        branch = self._ref.removeprefix("origin/")
+        valid = self._process.run(
+            ("git", "check-ref-format", "--branch", branch),
+            self._repository_path,
+            timeout=GIT_OPERATION_TIMEOUT_SECONDS,
+        )
+        if not valid.success:
+            raise ExecutionSourceError(
+                f"execution source ref is not a valid origin branch: {self._ref}"
+            )
+        self._run_or_raise(
+            (
+                "git",
+                "fetch",
+                "--no-tags",
+                "origin",
+                f"+refs/heads/{branch}:refs/remotes/origin/{branch}",
+            ),
+            self._repository_path,
+            "execution source refresh failed",
+        )
+
+    def _resolve_commit(self) -> str:
+        result = self._process.run(
+            (
+                "git",
+                "rev-parse",
+                "--verify",
+                "--quiet",
+                "--end-of-options",
+                f"{self._ref}^{{commit}}",
+            ),
+            self._repository_path,
+            timeout=GIT_OPERATION_TIMEOUT_SECONDS,
+        )
+        if not result.success or not result.stdout.strip():
+            raise ExecutionSourceError(
+                f"execution source ref does not resolve to a commit: {self._ref}"
+            )
+        return result.stdout.strip()
+
+    def _validate_snapshot(self, snapshot: Path, expected_common_dir: Path) -> str:
+        if not snapshot.is_dir():
+            raise ExecutionSourceError(
+                f"execution source path is not a directory: {snapshot}"
+            )
+        snapshot_common = self._git_value(
+            ("git", "rev-parse", "--git-common-dir"),
+            snapshot,
+            "could not identify managed execution source repository",
+        )
+        common_path = Path(snapshot_common)
+        normalized_common = (
+            common_path.resolve()
+            if common_path.is_absolute()
+            else (snapshot / common_path).resolve()
+        )
+        if normalized_common != expected_common_dir:
+            raise ExecutionSourceError(
+                f"managed execution source belongs to a different repository: {snapshot}"
+            )
+        head = self._git_value(
+            ("git", "rev-parse", "HEAD"),
+            snapshot,
+            "could not resolve managed execution source HEAD",
+        )
+        branch = self._process.run(
+            ("git", "symbolic-ref", "--quiet", "HEAD"),
+            snapshot,
+            timeout=GIT_OPERATION_TIMEOUT_SECONDS,
+        )
+        if branch.success or branch.exit_code != 1:
+            raise ExecutionSourceError(
+                f"managed execution source is not detached: {snapshot}"
+            )
+        status = self._process.run(
+            ("git", "status", "--porcelain"),
+            snapshot,
+            timeout=GIT_OPERATION_TIMEOUT_SECONDS,
+        )
+        if not status.success or status.stdout.strip():
+            raise ExecutionSourceError(
+                f"managed execution source is not clean: {snapshot}"
+            )
+        return head
+
+    def _git_value(self, argv: tuple[str, ...], cwd: Path, action: str) -> str:
+        result = self._process.run(
+            argv,
+            cwd,
+            timeout=GIT_OPERATION_TIMEOUT_SECONDS,
+        )
+        if not result.success or not result.stdout.strip():
+            detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+            raise ExecutionSourceError(f"{action}: {detail}")
+        return result.stdout.strip()
+
+    def _run_or_raise(self, argv: tuple[str, ...], cwd: Path, action: str) -> None:
+        result = self._process.run(
+            argv,
+            cwd,
+            timeout=GIT_OPERATION_TIMEOUT_SECONDS,
+        )
+        if not result.success:
+            detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+            raise ExecutionSourceError(f"{action}: {detail}")

--- a/groundskeeper/adapters/execution_source.py
+++ b/groundskeeper/adapters/execution_source.py
@@ -41,10 +41,17 @@ def resolve_execution_path(snapshot: Path, configured: Path) -> Path:
 def validate_execution_tree(snapshot: Path, tree: Path) -> None:
     """Reject symlinks that let scheduled inputs escape their Git snapshot."""
     if not tree.exists():
+        if tree.is_symlink():
+            raise ExecutionSourceError(
+                "scheduled input cannot be resolved inside its execution snapshot: "
+                f"{tree}"
+            )
         return
     resolved_snapshot = snapshot.resolve()
-    candidates = [tree, *tree.rglob("*")]
-    for candidate in candidates:
+    pending = [tree]
+    visited_directories: set[Path] = set()
+    while pending:
+        candidate = pending.pop()
         try:
             resolved = candidate.resolve(strict=True)
         except OSError as error:
@@ -57,6 +64,16 @@ def validate_execution_tree(snapshot: Path, tree: Path) -> None:
                 "scheduled inputs must remain inside their execution snapshot: "
                 f"{candidate}"
             )
+        if not resolved.is_dir() or resolved in visited_directories:
+            continue
+        visited_directories.add(resolved)
+        try:
+            pending.extend(resolved.iterdir())
+        except OSError as error:
+            raise ExecutionSourceError(
+                "scheduled input cannot be traversed inside its execution snapshot: "
+                f"{candidate}"
+            ) from error
 
 
 class ExecutionSourceManager:

--- a/groundskeeper/adapters/scheduler_state.py
+++ b/groundskeeper/adapters/scheduler_state.py
@@ -1,0 +1,127 @@
+"""Locked file-backed state for host-local scheduled automation."""
+
+from __future__ import annotations
+
+import fcntl
+import json
+from datetime import date
+from pathlib import Path
+from types import TracebackType
+from typing import TextIO
+
+
+class SchedulerStateError(RuntimeError):
+    """Scheduled automation state cannot be interpreted or persisted safely."""
+
+
+class DailyQuotaLedger:
+    """Persist task reservations consumed on one local calendar day."""
+
+    def __init__(self, path: Path, day: date, limit: int) -> None:
+        if limit <= 0:
+            raise ValueError("daily attempt limit must be positive")
+        self.path = path
+        self.day = day
+        self.limit = limit
+        self.consumed = 0
+        self._lock_file: TextIO | None = None
+
+    def __enter__(self) -> DailyQuotaLedger:
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+            self._lock_file = lock_path.open("a+", encoding="utf-8")
+            fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_EX)
+            self._load()
+            self._persist()
+        except (OSError, json.JSONDecodeError, SchedulerStateError) as error:
+            self._release()
+            if isinstance(error, SchedulerStateError):
+                raise
+            raise SchedulerStateError(
+                f"cannot safely open daily quota ledger {self.path}: {error}"
+            ) from error
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self._release()
+
+    @property
+    def remaining(self) -> int:
+        """Return task reservations still available today."""
+        return max(0, self.limit - self.consumed)
+
+    def consume(self) -> None:
+        """Durably reserve one available task attempt."""
+        if self.remaining <= 0:
+            return
+        self.consumed += 1
+        self._persist()
+
+    def refund(self) -> None:
+        """Refund one reservation after a proven non-attempt result."""
+        if self.consumed <= 0:
+            raise SchedulerStateError("cannot refund an unreserved daily attempt")
+        self.consumed -= 1
+        self._persist()
+
+    def _load(self) -> None:
+        if not self.path.is_file():
+            return
+        try:
+            payload = json.loads(self.path.read_text())
+        except (OSError, json.JSONDecodeError) as error:
+            raise SchedulerStateError(
+                f"cannot safely read daily quota ledger {self.path}: {error}"
+            ) from error
+        if not isinstance(payload, dict) or set(payload) != {"date", "consumed"}:
+            raise SchedulerStateError(
+                f"daily quota ledger has invalid schema: {self.path}"
+            )
+        stored_date = payload["date"]
+        stored = payload["consumed"]
+        if not isinstance(stored_date, str):
+            raise SchedulerStateError(
+                f"daily quota ledger has invalid date: {self.path}"
+            )
+        try:
+            parsed_date = date.fromisoformat(stored_date)
+        except ValueError as error:
+            raise SchedulerStateError(
+                f"daily quota ledger has invalid date: {self.path}"
+            ) from error
+        if parsed_date > self.day:
+            raise SchedulerStateError(
+                f"daily quota ledger date is in the future: {self.path}"
+            )
+        if not isinstance(stored, int) or isinstance(stored, bool) or stored < 0:
+            raise SchedulerStateError(
+                f"daily quota ledger has invalid consumed count: {self.path}"
+            )
+        if parsed_date == self.day:
+            self.consumed = stored
+
+    def _persist(self) -> None:
+        temporary = self.path.with_suffix(self.path.suffix + ".tmp")
+        try:
+            temporary.write_text(
+                json.dumps({"date": self.day.isoformat(), "consumed": self.consumed})
+            )
+            temporary.replace(self.path)
+        except OSError as error:
+            raise SchedulerStateError(
+                f"cannot safely persist daily quota ledger {self.path}: {error}"
+            ) from error
+
+    def _release(self) -> None:
+        if self._lock_file is not None:
+            try:
+                fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_UN)
+            finally:
+                self._lock_file.close()
+                self._lock_file = None

--- a/groundskeeper/adapters/scheduler_state.py
+++ b/groundskeeper/adapters/scheduler_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import fcntl
 import json
+import os
 from datetime import date
 from pathlib import Path
 from types import TracebackType
@@ -12,6 +13,30 @@ from typing import TextIO
 
 class SchedulerStateError(RuntimeError):
     """Scheduled automation state cannot be interpreted or persisted safely."""
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist directory entries created or replaced directly below path."""
+    directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    directory_fd = os.open(path, directory_flags)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
+def _create_directory_chain_durably(path: Path) -> None:
+    """Create missing directories and persist each new parent entry."""
+    missing: list[Path] = []
+    current = path
+    while not current.exists():
+        missing.append(current)
+        if current == current.parent:
+            break
+        current = current.parent
+    for directory in reversed(missing):
+        directory.mkdir(exist_ok=True)
+        _fsync_directory(directory.parent)
 
 
 class DailyQuotaLedger:
@@ -28,7 +53,7 @@ class DailyQuotaLedger:
 
     def __enter__(self) -> DailyQuotaLedger:
         try:
-            self.path.parent.mkdir(parents=True, exist_ok=True)
+            _create_directory_chain_durably(self.path.parent)
             lock_path = self.path.with_suffix(self.path.suffix + ".lock")
             self._lock_file = lock_path.open("a+", encoding="utf-8")
             fcntl.flock(self._lock_file.fileno(), fcntl.LOCK_EX)
@@ -108,11 +133,16 @@ class DailyQuotaLedger:
 
     def _persist(self) -> None:
         temporary = self.path.with_suffix(self.path.suffix + ".tmp")
+        payload = json.dumps(
+            {"date": self.day.isoformat(), "consumed": self.consumed}
+        ).encode()
         try:
-            temporary.write_text(
-                json.dumps({"date": self.day.isoformat(), "consumed": self.consumed})
-            )
-            temporary.replace(self.path)
+            with temporary.open("wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.path)
+            _fsync_directory(self.path.parent)
         except OSError as error:
             raise SchedulerStateError(
                 f"cannot safely persist daily quota ledger {self.path}: {error}"

--- a/groundskeeper/adapters/tick_lock.py
+++ b/groundskeeper/adapters/tick_lock.py
@@ -12,6 +12,10 @@ class TickAlreadyRunningError(RuntimeError):
     """Another process on this host owns the automation tick."""
 
 
+class TickLockError(RuntimeError):
+    """The host-local lock path cannot be opened safely."""
+
+
 class TickLock:
     """Advisory lock released automatically on process exit."""
 
@@ -20,8 +24,14 @@ class TickLock:
         self._handle: TextIO | None = None
 
     def __enter__(self) -> TickLock:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        self._handle = self._path.open("a+", encoding="utf-8")
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._handle = self._path.open("a+", encoding="utf-8")
+        except OSError as error:
+            self._handle = None
+            raise TickLockError(
+                f"could not open host-local tick lock {self._path}: {error}"
+            ) from error
         try:
             fcntl.flock(self._handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError as error:

--- a/groundskeeper/cli/main.py
+++ b/groundskeeper/cli/main.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import shutil
 from contextlib import ExitStack
+from datetime import date
 from pathlib import Path
 
 import click
@@ -33,6 +35,7 @@ from groundskeeper.adapters.target_checkout import (
 )
 from groundskeeper.adapters.tick_lock import TickLock
 from groundskeeper.automation import AutomationService
+from groundskeeper.domain.automation import TickResult
 from groundskeeper.domain.config import (
     Automation,
     ParallelGroup,
@@ -51,6 +54,11 @@ from groundskeeper.domain.errors import (
 from groundskeeper.domain.models import RunContext, RunResult, Skill
 from groundskeeper.domain.parser import parse_skill_file
 from groundskeeper.protocols import SkillStore
+from groundskeeper.scheduler import (
+    ScheduledAutomationService,
+    ScheduledRunRequest,
+    ScheduledTick,
+)
 
 
 def _get_stores(
@@ -101,6 +109,7 @@ def cli(ctx: click.Context, skill_path: tuple[str, ...]) -> None:
 
 
 JSON_VERSION = 2
+_SCHEDULE_ID_RE = re.compile(r"^[a-z][a-z0-9]*(-[a-z0-9]+)*$")
 
 
 class AutomationCommandError(click.ClickException):
@@ -541,6 +550,118 @@ def automation_inspect(ctx: click.Context, name: str, json_output: bool) -> None
     click.echo(json.dumps(data, indent=2))
 
 
+def _automation_task_data(result: TickResult) -> dict[str, object] | None:
+    """Return the public task identity for one tick result."""
+    if result.task is None:
+        return None
+    return {
+        "id": str(result.task.source_issue.number),
+        "title": result.task.title,
+        "url": result.task.url,
+        "source": {
+            "repository": result.task.source_issue.repository,
+            "issue": result.task.source_issue.number,
+        },
+        "target": {"repository": result.task.target_repository},
+        "state": result.task.state.value,
+    }
+
+
+def _automation_tick_exit_code(status: str) -> int:
+    """Map the stable tick status contract to its process exit code."""
+    return {
+        "no-work": 0,
+        "review": 0,
+        "deferred": 0,
+        "would-dispatch": 0,
+        "would-resume": 0,
+        "would-block": 0,
+        "not-claimed": 4,
+        "blocked": 5,
+    }.get(status, 2)
+
+
+def _execute_automation_tick(
+    config_path: Path,
+    name: str,
+    extra_skill_paths: tuple[str, ...],
+    *,
+    dry_run: bool = False,
+) -> tuple[Automation, TickResult]:
+    """Execute one tick through the same lifecycle used by the CLI command."""
+    definition = _load_automation(config_path, name)
+    process = ProcessClient()
+    if dry_run:
+        runner = _build_automation_runner(
+            definition,
+            config_path,
+            extra_skill_paths,
+            process,
+            require_available=False,
+        )
+        tracker = GitHubIssuesTracker(
+            GhClient(process, definition.target.repository_path),
+            definition.source,
+            definition.target.repository,
+        )
+        service = AutomationService(tracker, runner)
+        return definition, service.tick(definition, dry_run=True)
+
+    target_common_dir = target_checkout_common_dir(
+        process, definition.target.repository_path
+    )
+    with ExitStack() as locks:
+        locks.enter_context(TickLock(_automation_lock_path(definition)))
+        locks.enter_context(
+            TickLock(_automation_target_lock_path(definition, target_common_dir))
+        )
+        runner = _build_automation_runner(
+            definition,
+            config_path,
+            extra_skill_paths,
+            process,
+            refresh_target=True,
+        )
+        tracker = GitHubIssuesTracker(
+            GhClient(process, definition.target.repository_path),
+            definition.source,
+            definition.target.repository,
+        )
+        service = AutomationService(tracker, runner)
+        return definition, service.tick(definition, dry_run=False)
+
+
+def _preflight_scheduled_automations(
+    config_path: Path,
+    requested_names: tuple[str, ...],
+    extra_skill_paths: tuple[str, ...],
+) -> list[str]:
+    """Validate every scheduled automation before opening daily quota state."""
+    definitions = get_automations(load_config(config_path))
+    available = {definition.name: definition for definition in definitions}
+    names = list(requested_names) if requested_names else list(available)
+    if not names:
+        raise ConfigError("No automations configured for the scheduled run.")
+    if len(set(names)) != len(names):
+        raise ConfigError("Scheduled automation names must be unique.")
+    process = ProcessClient()
+    for name in names:
+        definition = available.get(name)
+        if definition is None:
+            raise ConfigError(
+                f"Automation not found: {name}. Run 'gk automation list'."
+            )
+        skill = _resolve_automation_skill(definition, config_path, extra_skill_paths)
+        _build_automation_runner(
+            definition,
+            config_path,
+            extra_skill_paths,
+            process,
+            skill=skill,
+        )
+    return names
+
+
 @automation.command(
     "tick",
     epilog="""
@@ -569,82 +690,25 @@ def automation_tick(
     config_path = _automation_config_path(ctx)
     extra = ctx.obj.get("extra_skill_paths", ()) if ctx.obj else ()
     try:
-        definition = _load_automation(config_path, name)
-        process = ProcessClient()
-        if dry_run:
-            runner = _build_automation_runner(
-                definition, config_path, extra, process, require_available=False
-            )
-            tracker = GitHubIssuesTracker(
-                GhClient(process, definition.target.repository_path),
-                definition.source,
-                definition.target.repository,
-            )
-            service = AutomationService(tracker, runner)
-            result = service.tick(definition, dry_run=True)
-        else:
-            target_common_dir = target_checkout_common_dir(
-                process, definition.target.repository_path
-            )
-            with ExitStack() as locks:
-                locks.enter_context(TickLock(_automation_lock_path(definition)))
-                locks.enter_context(
-                    TickLock(
-                        _automation_target_lock_path(definition, target_common_dir)
-                    )
-                )
-                runner = _build_automation_runner(
-                    definition,
-                    config_path,
-                    extra,
-                    process,
-                    refresh_target=True,
-                )
-                tracker = GitHubIssuesTracker(
-                    GhClient(process, definition.target.repository_path),
-                    definition.source,
-                    definition.target.repository,
-                )
-                service = AutomationService(tracker, runner)
-                result = service.tick(definition, dry_run=False)
+        definition, result = _execute_automation_tick(
+            config_path, name, extra, dry_run=dry_run
+        )
     except (ConfigError, RuntimeError) as error:
         _automation_error(str(error), json_output)
         return
 
-    task_data = None
-    if result.task is not None:
-        task_data = {
-            "id": str(result.task.source_issue.number),
-            "title": result.task.title,
-            "url": result.task.url,
-            "source": {
-                "repository": result.task.source_issue.repository,
-                "issue": result.task.source_issue.number,
-            },
-            "target": {"repository": result.task.target_repository},
-            "state": result.task.state.value,
-        }
     data: dict[str, object] = {
         "automation": result.automation,
         "source": {"repository": definition.source.repository},
         "target": _automation_target_summary(definition),
-        "task": task_data,
+        "task": _automation_task_data(result),
         "pull_request_url": result.pull_request_url,
         "detail": result.detail,
         "session_id": result.session_id,
         "session_name": result.session_name,
         "resume_command": result.resume_command,
     }
-    exit_code = {
-        "no-work": 0,
-        "review": 0,
-        "deferred": 0,
-        "would-dispatch": 0,
-        "would-resume": 0,
-        "would-block": 0,
-        "not-claimed": 4,
-        "blocked": 5,
-    }.get(result.status, 2)
+    exit_code = _automation_tick_exit_code(result.status)
     if json_output:
         click.echo(_automation_envelope(result.status, data, exit_code))
     else:
@@ -653,6 +717,173 @@ def automation_tick(
         )
     if exit_code:
         raise SystemExit(exit_code)
+
+
+@automation.command(
+    "run-scheduled",
+    epilog="""
+\b
+Examples:
+  gk automation --config .groundskeeper/config.yml run-scheduled \
+    --schedule-id personal --source-repository-path ~/dots --daily-attempt-limit 5
+  gk automation --config .groundskeeper/config.work.yml run-scheduled discord-dev \
+    --schedule-id work --source-repository-path ~/dots --daily-attempt-limit 1
+
+Exit codes: 0 completed/no work, 2 preflight, state, or automation failure.
+""",
+)
+@click.argument("names", nargs=-1)
+@click.option(
+    "--schedule-id",
+    required=True,
+    help="Stable kebab-case identity for locks and daily quota state.",
+)
+@click.option(
+    "--source-repository-path",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    required=True,
+    help="Git donor used only to resolve and materialize the execution snapshot.",
+)
+@click.option(
+    "--source-ref",
+    default="origin/main",
+    show_default=True,
+    help="Commit-ish containing the scheduled config and local skills.",
+)
+@click.option(
+    "--source-refresh",
+    type=click.Choice(["none", "fetch"]),
+    default="fetch",
+    show_default=True,
+    help="Refresh origin/* before pinning the execution snapshot.",
+)
+@click.option(
+    "--daily-attempt-limit",
+    type=click.IntRange(min=1),
+    required=True,
+    help="Maximum worker attempts shared by this schedule each local day.",
+)
+@click.option(
+    "--rotation",
+    type=click.Choice(["daily", "fixed"]),
+    default="daily",
+    show_default=True,
+    help="Rotate the first automation daily or preserve declaration order.",
+)
+@click.option("--json", "json_output", is_flag=True, help="Emit versioned JSON output.")
+@click.pass_context
+def automation_run_scheduled(
+    ctx: click.Context,
+    names: tuple[str, ...],
+    schedule_id: str,
+    source_repository_path: Path,
+    source_ref: str,
+    source_refresh: str,
+    daily_attempt_limit: int,
+    rotation: str,
+    json_output: bool,
+) -> None:
+    """Run automations from an immutable managed configuration snapshot.
+
+    Use this as the stable command behind launchd, systemd, cron, or another
+    host scheduler. The donor checkout may be dirty: Groundskeeper fetches and
+    pins SOURCE_REF, executes config and local skills from a detached managed
+    worktree, and never checks out, resets, stashes, or cleans the donor.
+    """
+    if not _SCHEDULE_ID_RE.fullmatch(schedule_id):
+        _automation_error("Schedule id must be kebab-case.", json_output)
+        return
+    configured_path = _automation_config_path(ctx)
+    extra = ctx.obj.get("extra_skill_paths", ()) if ctx.obj else ()
+    if extra:
+        _automation_error(
+            "run-scheduled does not accept --skill-path; scheduled skills must "
+            "come from the pinned execution snapshot or builtins.",
+            json_output,
+        )
+        return
+    today = date.today()
+    request = ScheduledRunRequest(
+        schedule_id=schedule_id,
+        source_repository_path=source_repository_path,
+        source_ref=source_ref,
+        source_refresh=source_refresh,
+        config_path=configured_path,
+        names=names,
+        daily_attempt_limit=daily_attempt_limit,
+        rotation=today.toordinal() if rotation == "daily" else 0,
+        day=today,
+    )
+    service = ScheduledAutomationService(_automation_state_root(), ProcessClient())
+
+    def preflight(config_path: Path, selected: tuple[str, ...]) -> list[str]:
+        return _preflight_scheduled_automations(config_path, selected, ())
+
+    def tick(config_path: Path, name: str) -> ScheduledTick:
+        try:
+            _definition, result = _execute_automation_tick(config_path, name, ())
+        except (ConfigError, RuntimeError) as error:
+            return ScheduledTick(name, "error", 2, None, str(error))
+        return ScheduledTick(
+            name,
+            result.status,
+            _automation_tick_exit_code(result.status),
+            _automation_task_data(result),
+            result.detail or None,
+            result.pull_request_url,
+        )
+
+    try:
+        scheduled = service.run(request, preflight=preflight, tick=tick)
+    except (ConfigError, RuntimeError, ValueError) as error:
+        _automation_error(str(error), json_output)
+        return
+
+    runs = scheduled.runs
+    consumed = scheduled.consumed_today
+    source = scheduled.execution_source
+    run_data = [
+        {
+            "automation": run.automation,
+            "status": run.status,
+            "exit_code": run.exit_code,
+            "consumed_attempt": run.consumed_attempt,
+            "task": run.task,
+            "pull_request_url": run.pull_request_url,
+            "detail": run.detail,
+        }
+        for run in runs
+    ]
+    failed = any(run.exit_code != 0 for run in runs)
+    data: dict[str, object] = {
+        "schedule": schedule_id,
+        "execution_source": {
+            "repository_path": str(source_repository_path.resolve()),
+            "ref": source_ref,
+            "commit": source.commit,
+            "workspace": str(source.path),
+        },
+        "date": today.isoformat(),
+        "limit": daily_attempt_limit,
+        "consumed_today": consumed,
+        "remaining_today": max(0, daily_attempt_limit - consumed),
+        "runs": run_data,
+    }
+    if json_output:
+        click.echo(
+            _automation_envelope(
+                "error" if failed else "ok",
+                data,
+                exit_code=2 if failed else 0,
+            )
+        )
+    else:
+        click.echo(
+            f"{'error' if failed else 'ok'}: {len(runs)} tick(s), "
+            f"{consumed}/{daily_attempt_limit} attempts consumed"
+        )
+    if failed:
+        raise SystemExit(2)
 
 
 @cli.command(

--- a/groundskeeper/scheduler.py
+++ b/groundskeeper/scheduler.py
@@ -1,0 +1,171 @@
+"""Application lifecycle for host-local scheduled automation."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from datetime import date
+from pathlib import Path
+
+from groundskeeper.adapters.execution_source import (
+    ExecutionSource,
+    ExecutionSourceManager,
+    resolve_execution_path,
+    validate_execution_tree,
+)
+from groundskeeper.adapters.process import ProcessClient
+from groundskeeper.adapters.scheduler_state import DailyQuotaLedger
+from groundskeeper.adapters.tick_lock import TickLock
+
+
+class SchedulerError(RuntimeError):
+    """A scheduled run cannot proceed without violating its contract."""
+
+
+@dataclass(frozen=True)
+class ScheduledTick:
+    """Normalized result from one internal automation tick."""
+
+    automation: str
+    status: str
+    exit_code: int
+    task: dict[str, object] | None
+    detail: str | None = None
+    pull_request_url: str | None = None
+    consumed_attempt: bool = False
+
+
+@dataclass(frozen=True)
+class ScheduledRunRequest:
+    """Typed policy for one invocation by a host scheduler."""
+
+    schedule_id: str
+    source_repository_path: Path
+    source_ref: str
+    source_refresh: str
+    config_path: Path
+    names: tuple[str, ...]
+    daily_attempt_limit: int
+    rotation: int
+    day: date
+
+
+@dataclass(frozen=True)
+class ScheduledRun:
+    """Complete deterministic result of one scheduled invocation."""
+
+    request: ScheduledRunRequest
+    execution_source: ExecutionSource
+    consumed_today: int
+    runs: tuple[ScheduledTick, ...]
+
+
+PreflightScheduled = Callable[[Path, tuple[str, ...]], list[str]]
+TickScheduled = Callable[[Path, str], ScheduledTick]
+
+
+class ScheduledAutomationService:
+    """Own source pinning, locks, preflight, quota, and tick ordering."""
+
+    def __init__(self, state_root: Path, process: ProcessClient) -> None:
+        self._state_root = state_root
+        self._process = process
+
+    def run(
+        self,
+        request: ScheduledRunRequest,
+        *,
+        preflight: PreflightScheduled,
+        tick: TickScheduled,
+    ) -> ScheduledRun:
+        """Execute a request from one immutable source snapshot."""
+        manager = ExecutionSourceManager(
+            self._process,
+            request.source_repository_path,
+            request.source_ref,
+            request.source_refresh,
+            self._state_root,
+        )
+        common_dir = manager.common_dir()
+        with TickLock(self._schedule_lock_path(request.schedule_id)):
+            # Keep the source lock for the complete run. The managed worktree is
+            # a bounded reusable lease and cannot advance while callbacks read it.
+            with TickLock(self._source_lock_path(common_dir)):
+                source = manager.prepare()
+                config_path = resolve_execution_path(source.path, request.config_path)
+                if not config_path.is_file():
+                    raise SchedulerError(
+                        f"scheduled automation config does not exist: {config_path}"
+                    )
+                validate_execution_tree(source.path, config_path.parent / "skills")
+                selected_names = preflight(config_path, request.names)
+                with DailyQuotaLedger(
+                    self._quota_path(request.schedule_id),
+                    request.day,
+                    request.daily_attempt_limit,
+                ) as quota:
+                    runs = run_scheduled_automations(
+                        selected_names,
+                        quota,
+                        rotation=request.rotation,
+                        tick=lambda name: tick(config_path, name),
+                    )
+                    consumed = quota.consumed
+        return ScheduledRun(request, source, consumed, tuple(runs))
+
+    def _source_lock_path(self, git_common_dir: Path) -> Path:
+        """Serialize all fetch and worktree mutations in one Git common dir."""
+        source_key = hashlib.sha256(str(git_common_dir.resolve()).encode()).hexdigest()[
+            :16
+        ]
+        return self._state_root / "locks" / f"execution-source-{source_key}.lock"
+
+    def _schedule_lock_path(self, schedule_id: str) -> Path:
+        return self._state_root / "locks" / f"schedule-{schedule_id}.lock"
+
+    def _quota_path(self, schedule_id: str) -> Path:
+        return self._state_root / "schedules" / schedule_id / "daily-quota.json"
+
+
+def run_scheduled_automations(
+    names: list[str],
+    ledger: DailyQuotaLedger,
+    *,
+    rotation: int,
+    tick: Callable[[str], ScheduledTick],
+) -> list[ScheduledTick]:
+    """Run sequential ticks under one crash-safe shared daily quota."""
+    if not names or ledger.remaining <= 0:
+        return []
+    offset = rotation % len(names)
+    active = names[offset:] + names[:offset]
+    results: list[ScheduledTick] = []
+
+    while active and ledger.remaining > 0:
+        next_pass: list[str] = []
+        for name in active:
+            if ledger.remaining <= 0:
+                break
+            ledger.consume()
+            result = tick(name)
+            reserved = True
+            if result.status in {"no-work", "not-claimed"}:
+                ledger.refund()
+                reserved = False
+            elif result.status in {"review", "deferred", "blocked"} and not isinstance(
+                result.task, dict
+            ):
+                result = replace(
+                    result,
+                    status="error",
+                    exit_code=2,
+                    detail="task status omitted its task object",
+                )
+
+            normalized = replace(result, consumed_attempt=reserved)
+            results.append(normalized)
+            if reserved and normalized.status in {"review", "blocked"}:
+                next_pass.append(name)
+        active = next_pass
+    return results

--- a/tests/adapters/test_execution_source.py
+++ b/tests/adapters/test_execution_source.py
@@ -141,3 +141,21 @@ def test_execution_tree_rejects_symlink_outside_snapshot(tmp_path: Path) -> None
 
     with pytest.raises(ExecutionSourceError, match="must remain inside"):
         validate_execution_tree(snapshot, skills)
+
+
+def test_execution_tree_rejects_escape_below_internal_directory_symlink(
+    tmp_path: Path,
+) -> None:
+    snapshot = tmp_path / "snapshot"
+    skills = snapshot / ".groundskeeper/skills"
+    internal = snapshot / "shared"
+    external = tmp_path / "mutable-skill"
+    skills.mkdir(parents=True)
+    internal.mkdir()
+    external.mkdir()
+    (skills / "linked").symlink_to(internal, target_is_directory=True)
+    (internal / "nested").symlink_to(external, target_is_directory=True)
+    (external / "SKILL.md").write_text("---\nname: escaped\n---\n")
+
+    with pytest.raises(ExecutionSourceError, match="must remain inside"):
+        validate_execution_tree(snapshot, skills)

--- a/tests/adapters/test_execution_source.py
+++ b/tests/adapters/test_execution_source.py
@@ -1,0 +1,143 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from groundskeeper.adapters.execution_source import (
+    ExecutionSourceError,
+    ExecutionSourceManager,
+    resolve_execution_path,
+    validate_execution_tree,
+)
+from groundskeeper.adapters.process import ProcessClient
+
+
+def _commit(repo: Path, message: str, content: str) -> str:
+    (repo / "config.txt").write_text(content)
+    subprocess.run(["git", "add", "config.txt"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Groundskeeper Test",
+            "-c",
+            "user.email=groundskeeper@example.com",
+            "commit",
+            "-qm",
+            message,
+        ],
+        cwd=repo,
+        check=True,
+    )
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_refresh_materializes_remote_commit_without_touching_dirty_donor(
+    tmp_path: Path,
+) -> None:
+    remote = tmp_path / "remote.git"
+    seed = tmp_path / "seed"
+    donor = tmp_path / "donor"
+    state = tmp_path / "state"
+    subprocess.run(["git", "init", "--bare", "-q", remote], check=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", seed], check=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(remote)], cwd=seed, check=True
+    )
+    first_sha = _commit(seed, "first", "first\n")
+    subprocess.run(["git", "push", "-q", "-u", "origin", "main"], cwd=seed, check=True)
+    subprocess.run(["git", "clone", "-q", "-b", "main", remote, donor], check=True)
+    (donor / "config.txt").write_text("dirty local value\n")
+    (donor / "untracked.txt").write_text("preserve me\n")
+    second_sha = _commit(seed, "second", "remote value\n")
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=seed, check=True)
+
+    manager = ExecutionSourceManager(
+        ProcessClient(),
+        donor,
+        "origin/main",
+        "fetch",
+        state,
+    )
+    source = manager.prepare()
+
+    assert first_sha != second_sha
+    assert source.commit == second_sha
+    assert source.path != donor
+    assert source.path.is_relative_to(state / "execution-sources")
+    assert (source.path / "config.txt").read_text() == "remote value\n"
+    assert (donor / "config.txt").read_text() == "dirty local value\n"
+    assert (donor / "untracked.txt").read_text() == "preserve me\n"
+
+    third_sha = _commit(seed, "third", "new remote value\n")
+    subprocess.run(["git", "push", "-q", "origin", "main"], cwd=seed, check=True)
+    advanced = manager.prepare()
+
+    assert advanced.path == source.path
+    assert advanced.commit == third_sha
+    assert (advanced.path / "config.txt").read_text() == "new remote value\n"
+    assert (donor / "config.txt").read_text() == "dirty local value\n"
+
+
+def test_reused_execution_source_must_remain_clean(tmp_path: Path) -> None:
+    donor = tmp_path / "donor"
+    subprocess.run(["git", "init", "-q", "-b", "main", donor], check=True)
+    _commit(donor, "base", "base\n")
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/main", "HEAD"],
+        cwd=donor,
+        check=True,
+    )
+    manager = ExecutionSourceManager(
+        ProcessClient(),
+        donor,
+        "origin/main",
+        "none",
+        tmp_path / "state",
+    )
+    source = manager.prepare()
+    (source.path / "unexpected.txt").write_text("dirty\n")
+
+    with pytest.raises(ExecutionSourceError, match="not clean"):
+        manager.prepare()
+
+
+@pytest.mark.parametrize(
+    "configured",
+    [
+        Path("/absolute/config.yml"),
+        Path("../outside.yml"),
+        Path("nested/../../outside.yml"),
+    ],
+)
+def test_execution_config_path_cannot_escape_snapshot(
+    tmp_path: Path, configured: Path
+) -> None:
+    with pytest.raises(ExecutionSourceError, match="relative path inside"):
+        resolve_execution_path(tmp_path / "snapshot", configured)
+
+
+def test_execution_config_path_resolves_inside_snapshot(tmp_path: Path) -> None:
+    snapshot = tmp_path / "snapshot"
+
+    resolved = resolve_execution_path(snapshot, Path(".groundskeeper/config.yml"))
+
+    assert resolved == snapshot / ".groundskeeper/config.yml"
+
+
+def test_execution_tree_rejects_symlink_outside_snapshot(tmp_path: Path) -> None:
+    snapshot = tmp_path / "snapshot"
+    skills = snapshot / ".groundskeeper/skills"
+    external = tmp_path / "mutable-skill"
+    skills.mkdir(parents=True)
+    external.mkdir()
+    (skills / "escaped").symlink_to(external, target_is_directory=True)
+
+    with pytest.raises(ExecutionSourceError, match="must remain inside"):
+        validate_execution_tree(snapshot, skills)

--- a/tests/adapters/test_tick_lock.py
+++ b/tests/adapters/test_tick_lock.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 import pytest
 
-from groundskeeper.adapters.tick_lock import TickAlreadyRunningError, TickLock
+from groundskeeper.adapters.tick_lock import (
+    TickAlreadyRunningError,
+    TickLock,
+    TickLockError,
+)
 
 
 def test_tick_lock_rejects_concurrent_owner_and_releases(tmp_path: Path) -> None:
@@ -13,3 +17,12 @@ def test_tick_lock_rejects_concurrent_owner_and_releases(tmp_path: Path) -> None
                 pass
     with TickLock(path):
         pass
+
+
+def test_tick_lock_translates_state_path_failure(tmp_path: Path) -> None:
+    parent_file = tmp_path / "not-a-directory"
+    parent_file.write_text("occupied")
+
+    with pytest.raises(TickLockError):
+        with TickLock(parent_file / "daily.lock"):
+            pass

--- a/tests/cli/test_cli_automation.py
+++ b/tests/cli/test_cli_automation.py
@@ -118,6 +118,32 @@ def test_automation_list_json(tmp_path: Path) -> None:
     }
 
 
+def test_scheduled_run_rejects_external_skill_paths(tmp_path: Path) -> None:
+    external = tmp_path / "external-skills"
+    external.mkdir()
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--skill-path",
+            str(external),
+            "automation",
+            "run-scheduled",
+            "--schedule-id",
+            "test-factory",
+            "--source-repository-path",
+            str(tmp_path),
+            "--daily-attempt-limit",
+            "1",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["status"] == "error"
+    assert payload["exit_code"] == 2
+
+
 def test_repository_locks_are_host_scoped_and_identity_stable(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/e2e/test_e2e_commands.py
+++ b/tests/e2e/test_e2e_commands.py
@@ -542,6 +542,130 @@ class TestAutomationE2E:
         assert (repo / "tracked.txt").read_text() == "donor base\n"
         assert (repo / "unrelated.txt").read_text() == "preserve me\n"
 
+    def test_scheduled_run_uses_origin_snapshot_and_preserves_dirty_source(
+        self, tmp_path: Path
+    ) -> None:
+        repo, env = _factory_flow_repo(tmp_path, "ready")
+        state_home = tmp_path / "state"
+        env["GROUNDSKEEPER_STATE_HOME"] = str(state_home)
+        real_git = shutil.which("git")
+        assert real_git is not None
+        remote = tmp_path / "source.git"
+        subprocess.run([real_git, "init", "--bare", "-q", remote], check=True)
+        subprocess.run([real_git, "switch", "-c", "main"], cwd=repo, check=True)
+        subprocess.run([real_git, "add", "."], cwd=repo, check=True)
+        subprocess.run(
+            [
+                real_git,
+                "-c",
+                "user.name=Groundskeeper Test",
+                "-c",
+                "user.email=groundskeeper@example.com",
+                "commit",
+                "-qm",
+                "scheduled source",
+            ],
+            cwd=repo,
+            check=True,
+        )
+        source_commit = subprocess.run(
+            [real_git, "rev-parse", "HEAD"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        subprocess.run(
+            [real_git, "remote", "set-url", "origin", remote], cwd=repo, check=True
+        )
+        subprocess.run(
+            [real_git, "push", "-q", "-u", "origin", "main"], cwd=repo, check=True
+        )
+        config_path = repo / ".groundskeeper/config.yml"
+        config_path.write_text("dirty: [invalid\n")
+        (repo / "local-notes.txt").write_text("preserve me\n")
+
+        binary_dir = tmp_path / "bin"
+        git_wrapper = binary_dir / "git"
+        git_wrapper.write_text(
+            "#!/bin/sh\n"
+            'if [ "$*" = "remote get-url origin" ]; then\n'
+            "  printf '%s\\n' 'git@github.com:target/repo.git'\n"
+            "  exit 0\n"
+            "fi\n"
+            f"exec '{real_git}' \"$@\"\n"
+        )
+        git_wrapper.chmod(0o755)
+
+        scheduled_args = (
+            "automation",
+            "--config",
+            ".groundskeeper/config.yml",
+            "run-scheduled",
+            "daily",
+            "--schedule-id",
+            "test-factory",
+            "--source-repository-path",
+            str(repo),
+            "--daily-attempt-limit",
+            "1",
+            "--rotation",
+            "fixed",
+            "--json",
+        )
+        result = run_gk(
+            *scheduled_args,
+            cwd=repo,
+            env=env,
+        )
+
+        assert result.returncode == 0, result.stderr
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "ok"
+        assert payload["data"]["execution_source"]["commit"] == source_commit
+        workspace = Path(payload["data"]["execution_source"]["workspace"])
+        assert workspace.is_relative_to(
+            state_home / "groundskeeper" / "execution-sources"
+        )
+        assert (
+            yaml.safe_load((workspace / ".groundskeeper/config.yml").read_text())[
+                "automations"
+            ]["daily"]["runner"]["skill"]
+            == "issue-implementation"
+        )
+        assert payload["data"]["runs"][0]["status"] == "review"
+        assert payload["data"]["consumed_today"] == 1
+        assert config_path.read_text() == "dirty: [invalid\n"
+        assert (repo / "local-notes.txt").read_text() == "preserve me\n"
+
+        quota_path = (
+            state_home
+            / "groundskeeper"
+            / "schedules"
+            / "test-factory"
+            / "daily-quota.json"
+        )
+        quota_path.write_text('{"date":null,"consumed":1}')
+        corrupt = run_gk(*scheduled_args, cwd=repo, env=env)
+
+        assert corrupt.returncode == 2
+        corrupt_payload = json.loads(corrupt.stdout)
+        assert corrupt_payload["status"] == "error"
+        assert corrupt_payload["exit_code"] == 2
+        assert "Traceback" not in corrupt.stderr
+
+        state_parent_file = tmp_path / "invalid-state-root"
+        state_parent_file.write_text("occupied")
+        invalid_state_env = dict(env)
+        invalid_state_env["GROUNDSKEEPER_STATE_HOME"] = str(state_parent_file)
+        invalid_state = run_gk(*scheduled_args, cwd=repo, env=invalid_state_env)
+
+        assert invalid_state.returncode == 2
+        invalid_state_payload = json.loads(invalid_state.stdout)
+        assert invalid_state_payload["status"] == "error"
+        assert invalid_state_payload["exit_code"] == 2
+        assert "Traceback" not in invalid_state.stderr
+
     def test_dry_run_is_compact_and_does_not_launch_pi_or_write_state(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,5 +1,6 @@
 from datetime import date
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -118,3 +119,57 @@ def test_state_path_failure_is_translated(tmp_path: Path) -> None:
     with pytest.raises(SchedulerStateError):
         with DailyQuotaLedger(parent_file / "daily-quota.json", date(2026, 7, 26), 1):
             pass
+
+
+def test_quota_persist_fsyncs_file_before_replace_and_directory_after(
+    tmp_path: Path,
+) -> None:
+    events: list[str] = []
+    path = tmp_path / "quota.json"
+
+    from groundskeeper.adapters import scheduler_state
+
+    real_replace = scheduler_state.os.replace
+    with (
+        patch.object(
+            scheduler_state.os,
+            "fsync",
+            side_effect=lambda _fd: events.append("fsync"),
+        ),
+        patch.object(
+            scheduler_state.os,
+            "replace",
+            side_effect=lambda source, destination: (
+                events.append("replace"),
+                real_replace(source, destination),
+            )[-1],
+        ),
+    ):
+        with DailyQuotaLedger(path, date(2026, 7, 26), 1):
+            pass
+
+    assert events == ["fsync", "replace", "fsync"]
+
+
+def test_first_quota_directory_chain_is_persisted_in_each_parent(
+    tmp_path: Path,
+) -> None:
+    directories: list[Path] = []
+    path = tmp_path / "state" / "schedules" / "daily" / "quota.json"
+
+    from groundskeeper.adapters import scheduler_state
+
+    with patch.object(
+        scheduler_state,
+        "_fsync_directory",
+        side_effect=lambda directory: directories.append(directory),
+    ):
+        with DailyQuotaLedger(path, date(2026, 7, 26), 1):
+            pass
+
+    assert directories == [
+        tmp_path,
+        tmp_path / "state",
+        tmp_path / "state" / "schedules",
+        tmp_path / "state" / "schedules" / "daily",
+    ]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,120 @@
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from groundskeeper.adapters.scheduler_state import (
+    DailyQuotaLedger,
+    SchedulerStateError,
+)
+from groundskeeper.scheduler import (
+    ScheduledTick,
+    run_scheduled_automations,
+)
+
+
+def test_reserved_non_attempt_is_refunded(tmp_path: Path) -> None:
+    ledger = DailyQuotaLedger(tmp_path / "quota.json", date(2026, 7, 26), 1)
+
+    with ledger:
+        runs = run_scheduled_automations(
+            ["one"],
+            ledger,
+            rotation=0,
+            tick=lambda name: ScheduledTick(name, "no-work", 0, None),
+        )
+
+    assert [(run.status, run.consumed_attempt) for run in runs] == [("no-work", False)]
+    assert ledger.consumed == 0
+
+
+def test_reserved_failure_remains_consumed(tmp_path: Path) -> None:
+    ledger = DailyQuotaLedger(tmp_path / "quota.json", date(2026, 7, 26), 1)
+
+    with ledger:
+        runs = run_scheduled_automations(
+            ["one"],
+            ledger,
+            rotation=0,
+            tick=lambda name: ScheduledTick(name, "error", 2, None),
+        )
+
+    assert runs[0].consumed_attempt is True
+    assert ledger.consumed == 1
+
+
+def test_scheduler_rotates_and_requeues_until_quota(tmp_path: Path) -> None:
+    ledger = DailyQuotaLedger(tmp_path / "quota.json", date(2026, 7, 26), 2)
+    calls: list[str] = []
+
+    def tick(name: str) -> ScheduledTick:
+        calls.append(name)
+        if name == "two":
+            return ScheduledTick(name, "no-work", 0, None)
+        return ScheduledTick(name, "review", 0, {"id": str(len(calls))})
+
+    with ledger:
+        runs = run_scheduled_automations(
+            ["one", "two", "three"],
+            ledger,
+            rotation=1,
+            tick=tick,
+        )
+
+    assert calls == ["two", "three", "one"]
+    assert [run.automation for run in runs] == calls
+    assert [run.consumed_attempt for run in runs] == [False, True, True]
+    assert ledger.consumed == 2
+
+
+def test_daily_quota_resets_on_a_new_day(tmp_path: Path) -> None:
+    path = tmp_path / "quota.json"
+    with DailyQuotaLedger(path, date(2026, 7, 26), 1) as first:
+        first.consume()
+
+    with DailyQuotaLedger(path, date(2026, 7, 27), 1) as second:
+        assert second.consumed == 0
+
+
+def test_lower_limit_does_not_erase_same_day_consumption(tmp_path: Path) -> None:
+    path = tmp_path / "quota.json"
+    with DailyQuotaLedger(path, date(2026, 7, 26), 5) as first:
+        for _ in range(5):
+            first.consume()
+
+    with DailyQuotaLedger(path, date(2026, 7, 26), 1) as lowered:
+        assert lowered.consumed == 5
+        assert lowered.remaining == 0
+
+    with DailyQuotaLedger(path, date(2026, 7, 26), 5) as restored:
+        assert restored.consumed == 5
+        assert restored.remaining == 0
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        '{"date":null,"consumed":0}',
+        '{"date":"not-a-date","consumed":0}',
+        '{"date":"2026-07-27","consumed":0}',
+        '{"date":"2026-07-26"}',
+    ],
+)
+def test_invalid_or_future_ledger_date_fails_closed(
+    tmp_path: Path, payload: str
+) -> None:
+    path = tmp_path / "quota.json"
+    path.write_text(payload)
+
+    with pytest.raises(SchedulerStateError):
+        with DailyQuotaLedger(path, date(2026, 7, 26), 1):
+            pass
+
+
+def test_state_path_failure_is_translated(tmp_path: Path) -> None:
+    parent_file = tmp_path / "not-a-directory"
+    parent_file.write_text("occupied")
+
+    with pytest.raises(SchedulerStateError):
+        with DailyQuotaLedger(parent_file / "daily-quota.json", date(2026, 7, 26), 1):
+            pass


### PR DESCRIPTION
## Why

Host schedulers currently have to execute repository-specific wrapper code from a developer checkout. That makes unrelated dirty files an automation preflight dependency and leaves source pinning, quota accounting, and tick ordering outside Groundskeeper.

This adds a generic installed-CLI scheduler entrypoint so host adapters only choose calendar timing, secrets, and runtime wiring.

## What changed

`gk automation ... run-scheduled` now:

- fetches and pins a configured Git ref, then reads configuration and local skills from a managed detached worktree;
- leaves the donor checkout untouched even when it is dirty or on another branch;
- rejects external skill paths, escaping config paths, and skill symlinks outside the pinned snapshot;
- serializes fetch and worktree operations by Git common directory while preventing overlapping runs of the same schedule;
- validates every selected automation before opening strict daily quota state;
- reserves quota before a mutating tick and refunds only a proven no-work or claim-contention result.

The managed source worktree is reused as the ref advances, avoiding unbounded worktree retention. Scheduler orchestration lives in an application module; Git and file-backed state remain adapter concerns.

## Proof

The installed-command E2E deliberately makes the donor configuration invalid and dirty, then demonstrates that the scheduled run uses the committed source snapshot and preserves donor files. The same test verifies structured JSON failures for corrupt quota state and an unusable state root.

The complete non-E2E suite (390 tests), installed E2E suite (39 tests), strict type/lint/format gate, and strict documentation build pass. Two independent architecture and quality reviews found no remaining actionable issues.

This PR adds the reusable Groundskeeper facility only. Migrating the existing Dots LaunchAgents is a separate downstream change.
