### PR TITLE
Configure factory PR handoff disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ runs skills on repository events.
 The first automation source is GitHub Issues and the first runner is Pi. A tick
 claims at most one trusted, explicitly-ready issue, renders its configured skill
 with a normalized task context, and runs it in Pi. Groundskeeper validates its
-fixed policy and enforces the accepted-result postcondition: only an open draft
-pull request with an exact GitHub closing reference reaches review. It does not
+fixed policy and enforces the accepted-result postcondition: only a verified
+open draft pull request reaches review. It does not
 sandbox Pi or prevent a user-authorized process from merging a pull request.
 
 ```yaml
@@ -43,17 +43,28 @@ automations:
       concurrency: 1
       output: draft-pr
       merge: never
+      link-source-issue: true
+      include-factory-session: true
+      include-pi-resume: true
 ```
 
 Create `issue-implementation` as an ordinary skill under
 `.groundskeeper/skills/`. It receives its usual prompt plus `TASK_ID`,
 `TASK_TITLE`, `TASK_BODY`, `TASK_URL`, `REPOSITORY`,
-`FACTORY_CLOSING_REFERENCE`, `RECOVERY_CONTEXT`, typed `TARGET_CHECKOUT_MODE`,
+`RECOVERY_CONTEXT`, typed `TARGET_CHECKOUT_MODE`,
 `TARGET_BASE_REF`, `TARGET_BASE_SHA`, `TARGET_REFRESH`,
 `TARGET_WORKSPACE_PATH`, and the fixed
-`POLICY_CONCURRENCY`, `POLICY_OUTPUT`, and `POLICY_MERGE` fields. `REPOSITORY`
-is the target repository. The closing reference is `#123` for a same-repository
-queue or `example/work-factory#123` for a cross-repository queue.
+`POLICY_CONCURRENCY`, `POLICY_OUTPUT`, `POLICY_MERGE`,
+`POLICY_LINK_SOURCE_ISSUE`, `POLICY_INCLUDE_FACTORY_SESSION`, and
+`POLICY_INCLUDE_PI_RESUME` fields. `REPOSITORY` is the target repository.
+When `link-source-issue` is true, the prompt also includes
+`FACTORY_CLOSING_REFERENCE`: `#123` for a same-repository queue or
+`example/work-factory#123` for a cross-repository queue. All three public
+handoff controls default to true. Disabling them tells the worker to omit that
+source or session metadata from the target pull request; Groundskeeper retains
+the recovery fields in its private execution context. Disabling source linking
+requires an `isolated-worktree` or `managed-worktree` target so Groundskeeper
+can verify the deterministic task branch.
 Normal `gk run` and `gk render` behavior for that skill is unchanged.
 
 ```bash
@@ -78,9 +89,9 @@ dirty working tree is neither inspected nor modified by Groundskeeper in
 task branch from the frozen SHA, runs Pi there, and reuses that same workspace
 and original base when recovering the deterministic session. Source issue
 discovery, admission, labels, dependencies, and comments stay in the source
-repository. Pull-request reconciliation queries the
-exact source issue's closing-PR connection and filters results to the target
-repository. `tick` is noninteractive and uses a host-local
+repository. Pull-request reconciliation uses either the exact source issue's
+closing-PR connection or the deterministic task branch, according to policy,
+and filters results to the target repository. `tick` is noninteractive and uses a host-local
 source-queue lock plus a target donor/worktree lock. Locks and deterministic
 task worktrees live under `$XDG_STATE_HOME/groundskeeper`
 (or `~/.local/state/groundskeeper`), so separate config worktrees share the
@@ -89,9 +100,8 @@ narrow host/test override. Run exactly one scheduler host for each automation;
 multi-host scheduling is not supported. A tick reconciles running work first,
 then atomically reclaims deferred work, then claims new ready work. A successful
 no-work tick is safe. Before dispatch and after any worker return, Groundskeeper
-reconciles the accepted GitHub result: an open draft PR in the target repository
-with the exact repository-qualified source issue closing reference moves to
-review even if the worker reported a late failure. If accepted and violating
+reconciles the accepted GitHub result: a policy-verified open draft PR in the
+target repository moves to review even if the worker reported a late failure. If accepted and violating
 exact target PRs coexist, the accepted draft wins; otherwise a non-draft, closed,
 or merged exact target PR blocks without dispatch. Explicit Codex usage,
 provider rate-limit/HTTP 429, and temporary provider-capacity failures move the
@@ -158,8 +168,9 @@ blocks the claimed issue with the command error and releases the host lock for r
 If a process exits after claiming an issue, the next tick resumes that session
 and reconciles GitHub state. Issue discovery requests ready, running, and
 deferred labels server-side and is bounded at 1,000 open issues per state.
-Pull request reconciliation inspects the exact source issue's repository-qualified
-closing pull request references and filters them to the configured target repository.
+Pull request reconciliation inspects either the exact source issue's
+repository-qualified closing pull request references or the deterministic task
+branch and filters them to the configured target repository.
 
 Define AI agent skills as markdown prompt templates. Chain them into workflows. Run them locally or generate GitHub Actions workflows that run them on PRs or schedules.
 

--- a/docs/config-and-skills.md
+++ b/docs/config-and-skills.md
@@ -31,15 +31,40 @@ optional strict `target.checkout` block selects an existing checkout or an
 isolated Groundskeeper-managed task worktree. Safety
 policy is strict: concurrency is `1`, output is `draft-pr`, and merge is `never`.
 Groundskeeper validates this policy and enforces the accepted-result
-postcondition: only an open draft pull request in the target repository that
-closes the exact repository-qualified source issue reaches review. It does not
-sandbox a user-authorized Pi process. An automation skill receives normalized
+postcondition: only an open draft pull request in the target repository reaches
+review. With `policy.link-source-issue: true`, Groundskeeper identifies that PR
+through GitHub's exact source-issue closing references. With it false,
+Groundskeeper identifies the PR through the deterministic automation branch.
+It does not sandbox a user-authorized Pi process. An automation skill receives normalized
 `TASK_ID`, `TASK_TITLE`, `TASK_BODY`, `TASK_URL`, target `REPOSITORY`, typed
-`FACTORY_CLOSING_REFERENCE`, `RECOVERY_CONTEXT`, and `POLICY_CONCURRENCY`,
-`POLICY_OUTPUT`, and `POLICY_MERGE`; checkout-aware workers also receive
+`RECOVERY_CONTEXT`, `POLICY_CONCURRENCY`, `POLICY_OUTPUT`, `POLICY_MERGE`,
+`POLICY_LINK_SOURCE_ISSUE`, `POLICY_INCLUDE_FACTORY_SESSION`, and
+`POLICY_INCLUDE_PI_RESUME`. When source linking is enabled it also receives
+`FACTORY_CLOSING_REFERENCE`; checkout-aware workers also receive
 `TARGET_CHECKOUT_MODE`, `TARGET_BASE_REF`, `TARGET_BASE_SHA`, and
 `TARGET_REFRESH`, plus the selected `TARGET_WORKSPACE_PATH`. Ordinary skill
 rendering is unchanged.
+
+Public target-PR disclosure is explicit policy:
+
+```yaml
+policy:
+  concurrency: 1
+  output: draft-pr
+  merge: never
+  link-source-issue: true
+  include-factory-session: true
+  include-pi-resume: true
+```
+
+The three disclosure fields are strict booleans and default to `true`.
+`link-source-issue: false` tells the worker not to link or mention the source
+queue issue in the target PR and changes reconciliation to the deterministic
+task branch, so it requires `target.checkout.mode: isolated-worktree` or
+`managed-worktree`. The other fields tell the worker whether factory-session identity
+and the Pi resume reference may appear in the target PR. Groundskeeper still
+provides those values in execution context for recovery and may record them on
+the source-side factory issue.
 
 Every GitHub Issues automation task must begin with exactly these first two H2
 sections. The contract sections cannot contain comments or fenced examples:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -107,14 +107,15 @@ Pi runner configuration accepts optional `timeout-seconds` (default: 7,200) for
 long-running tasks. GitHub CLI calls use a fixed 30-second timeout. Groundskeeper
 does not sandbox a user-authorized Pi process; it enforces its accepted-result
 postcondition by transitioning to review only for an open draft pull request in
-the target repository with the exact repository-qualified source issue closing
-reference. It queries the exact source issue's documented GraphQL
-`closedByPullRequestsReferences` connection, reads each pull request's repository
-identity, and filters to the configured target. It paginates that relevant
-connection and fails closed if its explicit page budget is exhausted. Before
-worker dispatch, an accepted exact open draft reaches review; otherwise an exact
-non-draft, closed, or merged target PR blocks. If accepted and violating target
-PRs coexist, the accepted open draft wins.
+the target repository. With `policy.link-source-issue: true`, it queries the
+exact source issue's documented GraphQL `closedByPullRequestsReferences`
+connection. With source linking disabled, it queries the deterministic
+Groundskeeper task branch; that mode requires an `isolated-worktree` or
+`managed-worktree` checkout. Both paths read repository identity, filter to the
+configured target, and fail closed on malformed results. Before worker
+dispatch, an accepted open draft reaches review; otherwise a non-draft, closed,
+or merged exact target PR blocks. If accepted and violating target PRs coexist,
+the accepted open draft wins.
 
 All automation JSON responses use the breaking v2 envelope:
 `{"version":2,"status":"...","data":{...},"exit_code":N}`. `list` and `show`

--- a/groundskeeper/adapters/automation_runner.py
+++ b/groundskeeper/adapters/automation_runner.py
@@ -83,17 +83,28 @@ class AutomationSkillRenderer:
         )
         normalized = task.task
         contract = task.contract
-        return "\n".join(
+        context = [
+            "AUTOMATION_CONTEXT",
+            f"TASK_ID: {normalized.source_issue.number}",
+            f"TASK_TITLE: {normalized.title}",
+            "TASK_BODY:",
+            normalized.body,
+            f"TASK_URL: {normalized.url}",
+            f"REPOSITORY: {normalized.target_repository}",
+            f"POLICY_LINK_SOURCE_ISSUE: {str(policy.link_source_issue).lower()}",
+            "POLICY_INCLUDE_FACTORY_SESSION: "
+            f"{str(policy.include_factory_session).lower()}",
+            f"POLICY_INCLUDE_PI_RESUME: {str(policy.include_pi_resume).lower()}",
+        ]
+        if policy.link_source_issue:
+            context.extend(
+                (
+                    "FACTORY_CLOSING_REFERENCE: "
+                    f"{normalized.source_issue.closing_reference(normalized.target_repository)}",
+                )
+            )
+        context.extend(
             (
-                "AUTOMATION_CONTEXT",
-                f"TASK_ID: {normalized.source_issue.number}",
-                f"TASK_TITLE: {normalized.title}",
-                "TASK_BODY:",
-                normalized.body,
-                f"TASK_URL: {normalized.url}",
-                f"REPOSITORY: {normalized.target_repository}",
-                "FACTORY_CLOSING_REFERENCE: "
-                f"{normalized.source_issue.closing_reference(normalized.target_repository)}",
                 f"FACTORY_TASK_KIND: {contract.kind.value}",
                 f"FACTORY_EXECUTION_MODE: {contract.mode.value if contract.mode else ''}",
                 "FACTORY_DEPENDENCY_STATUS: resolved",
@@ -111,6 +122,7 @@ class AutomationSkillRenderer:
                 f"RECOVERY_CONTEXT: {recovery_context}",
             )
         )
+        return "\n".join(context)
 
 
 class PiAutomationRunner:

--- a/groundskeeper/adapters/gh.py
+++ b/groundskeeper/adapters/gh.py
@@ -18,6 +18,7 @@ from groundskeeper.domain.task_contract import DependencyState, GitHubDependency
 GH_QUERY_TIMEOUT_SECONDS = 30
 GH_MUTATION_TIMEOUT_SECONDS = 30
 GH_CLOSING_PULL_REQUEST_PAGE_LIMIT = 10
+GH_BRANCH_PULL_REQUEST_LIMIT = 100
 
 _ISSUE_CLOSING_PULL_REQUESTS_QUERY = """
 query($owner: String!, $name: String!, $number: Int!, $endCursor: String) {
@@ -316,6 +317,91 @@ class GhClient:
                 else:
                     policy_violation = f"Closing pull request is not open: {url}"
         return PullRequestReconciliation(accepted_url, policy_violation)
+
+    def reconcile_branch_pull_requests(
+        self, target_repository: str, branch: str
+    ) -> PullRequestReconciliation:
+        """Read target pull requests for one deterministic automation branch."""
+        canonical_github_repository(target_repository)
+        result = self._process.run(
+            (
+                "gh",
+                "pr",
+                "list",
+                "--repo",
+                target_repository,
+                "--head",
+                branch,
+                "--state",
+                "all",
+                "--limit",
+                str(GH_BRANCH_PULL_REQUEST_LIMIT),
+                "--json",
+                "url,isDraft,state,headRefName,headRepository",
+            ),
+            self._cwd,
+            timeout=GH_QUERY_TIMEOUT_SECONDS,
+        )
+        if not result.success:
+            raise GhError(
+                result.stderr.strip() or "failed to query branch pull requests"
+            )
+        raw = self._parse_json(result.stdout, "branch pull request query")
+        if not isinstance(raw, list):
+            raise GhError("gh pr list returned an unexpected JSON shape")
+        if len(raw) >= GH_BRANCH_PULL_REQUEST_LIMIT:
+            raise GhError(
+                "branch pull request query reached the supported result limit"
+            )
+
+        accepted_url: str | None = None
+        policy_violation: str | None = None
+        try:
+            pull_requests = [
+                self._parse_branch_pull_request(item)
+                for item in cast(list[object], raw)
+            ]
+        except (TypeError, ValueError) as error:
+            raise GhError("gh pr list returned incomplete pull request data") from error
+        for repository, url, is_draft, state, head_branch in pull_requests:
+            if repository.casefold() != target_repository.casefold():
+                continue
+            if head_branch != branch:
+                continue
+            if is_draft and state == "OPEN":
+                accepted_url = accepted_url or url
+                continue
+            if policy_violation is None:
+                if not is_draft:
+                    policy_violation = f"Branch pull request is not a draft: {url}"
+                else:
+                    policy_violation = f"Branch pull request is not open: {url}"
+        return PullRequestReconciliation(accepted_url, policy_violation)
+
+    @staticmethod
+    def _parse_branch_pull_request(
+        value: object,
+    ) -> tuple[str, str, bool, str, str]:
+        if not isinstance(value, dict):
+            raise TypeError
+        pr_data = cast(dict[str, object], value)
+        repository = pr_data.get("headRepository")
+        if not isinstance(repository, dict):
+            raise TypeError
+        name_with_owner = cast(dict[str, object], repository).get("nameWithOwner")
+        url = pr_data.get("url")
+        is_draft = pr_data.get("isDraft")
+        state = pr_data.get("state")
+        branch = pr_data.get("headRefName")
+        if (
+            not isinstance(name_with_owner, str)
+            or not isinstance(url, str)
+            or not isinstance(is_draft, bool)
+            or state not in {"OPEN", "CLOSED", "MERGED"}
+            or not isinstance(branch, str)
+        ):
+            raise TypeError
+        return name_with_owner, url, is_draft, cast(str, state), branch
 
     @staticmethod
     def _parse_closing_pull_request_page(

--- a/groundskeeper/adapters/github_issues.py
+++ b/groundskeeper/adapters/github_issues.py
@@ -14,8 +14,9 @@ from groundskeeper.domain.automation import (
     GitHubIssueIdentity,
     PullRequestReconciliation,
     TaskState,
+    automation_task_branch,
 )
-from groundskeeper.domain.config import GitHubIssuesSource
+from groundskeeper.domain.config import AutomationPolicy, GitHubIssuesSource
 from groundskeeper.domain.task_contract import (
     DependencyState,
     FactoryTaskKind,
@@ -26,11 +27,16 @@ from groundskeeper.domain.task_contract import (
 
 class GitHubIssuesTracker:
     def __init__(
-        self, client: GhClient, source: GitHubIssuesSource, target_repository: str
+        self,
+        client: GhClient,
+        source: GitHubIssuesSource,
+        target_repository: str,
+        policy: AutomationPolicy,
     ) -> None:
         self._client = client
         self._source = source
         self._target_repository = target_repository
+        self._policy = policy
 
     def list_ready(self) -> list[AutomationTask]:
         return self._list_in_state(self._source.ready_label, TaskState.READY)
@@ -172,6 +178,10 @@ class GitHubIssuesTracker:
     def reconcile_pull_requests(
         self, task: AutomationTask
     ) -> PullRequestReconciliation:
+        if not self._policy.link_source_issue:
+            return self._client.reconcile_branch_pull_requests(
+                task.target_repository, automation_task_branch(task)
+            )
         return self._client.reconcile_pull_requests(
             task.target_repository, task.source_issue
         )

--- a/groundskeeper/adapters/target_checkout.py
+++ b/groundskeeper/adapters/target_checkout.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 from groundskeeper.adapters.process import ProcessClient
 from groundskeeper.domain.automation import (
     AutomationTask,
-    automation_task_identity,
+    automation_task_branch,
     canonical_github_repository,
 )
 from groundskeeper.domain.config import AutomationCheckout
@@ -76,7 +76,7 @@ class TargetCheckoutManager:
         """Return a nonmutating reason this task cannot use the managed target."""
         if self._checkout.mode != "managed-worktree":
             return None
-        branch_ref = f"refs/heads/{_task_branch(task)}"
+        branch_ref = f"refs/heads/{automation_task_branch(task)}"
         current_branch = _managed_worktree_branch(self._process, self._repository_path)
         status = self._process.run(
             ("git", "status", "--porcelain"),
@@ -107,7 +107,7 @@ class TargetCheckoutManager:
                 "isolated-worktree checkout has no resolved candidate base"
             )
 
-        branch = _task_branch(task)
+        branch = automation_task_branch(task)
         task_key = branch.removeprefix("groundskeeper/task-")
         target_key = hashlib.sha256(
             (
@@ -344,14 +344,6 @@ def _repository_from_remote(remote: str) -> str:
         raise TargetCheckoutError(
             "target checkout origin does not contain a canonical owner/repo identity"
         ) from error
-
-
-def _task_branch(task: AutomationTask) -> str:
-    """Return the deterministic local branch for one source task."""
-    task_key = hashlib.sha256(
-        automation_task_identity(task).encode("utf-8")
-    ).hexdigest()[:16]
-    return f"groundskeeper/task-{task_key}"
 
 
 def validate_target_checkout(

--- a/groundskeeper/cli/main.py
+++ b/groundskeeper/cli/main.py
@@ -193,6 +193,9 @@ def _automation_summary(
             "concurrency": item.policy.concurrency,
             "output": item.policy.output,
             "merge": item.policy.merge,
+            "link_source_issue": item.policy.link_source_issue,
+            "include_factory_session": item.policy.include_factory_session,
+            "include_pi_resume": item.policy.include_pi_resume,
         },
     }
     if skill is not None:
@@ -498,6 +501,7 @@ def automation_inspect(ctx: click.Context, name: str, json_output: bool) -> None
             GhClient(process, definition.target.repository_path),
             definition.source,
             definition.target.repository,
+            definition.policy,
         )
         tasks = [
             *tracker.list_running(),
@@ -604,6 +608,7 @@ def _execute_automation_tick(
             GhClient(process, definition.target.repository_path),
             definition.source,
             definition.target.repository,
+            definition.policy,
         )
         service = AutomationService(tracker, runner)
         return definition, service.tick(definition, dry_run=True)
@@ -627,6 +632,7 @@ def _execute_automation_tick(
             GhClient(process, definition.target.repository_path),
             definition.source,
             definition.target.repository,
+            definition.policy,
         )
         service = AutomationService(tracker, runner)
         return definition, service.tick(definition, dry_run=False)

--- a/groundskeeper/domain/automation.py
+++ b/groundskeeper/domain/automation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 from dataclasses import dataclass
 from enum import Enum
@@ -79,6 +80,14 @@ def automation_task_identity(task: AutomationTask) -> str:
         f"groundskeeper:{task.source_issue.repository.casefold()}:"
         f"{task.source_issue.number}:{task.target_repository.casefold()}"
     )
+
+
+def automation_task_branch(task: AutomationTask) -> str:
+    """Return the deterministic target branch used to identify one task PR."""
+    task_key = hashlib.sha256(
+        automation_task_identity(task).encode("utf-8")
+    ).hexdigest()[:16]
+    return f"groundskeeper/task-{task_key}"
 
 
 class AdmissionState(str, Enum):

--- a/groundskeeper/domain/config.py
+++ b/groundskeeper/domain/config.py
@@ -166,6 +166,9 @@ class AutomationPolicy:
     concurrency: int = 1
     output: str = "draft-pr"
     merge: str = "never"
+    link_source_issue: bool = True
+    include_factory_session: bool = True
+    include_pi_resume: bool = True
 
 
 @dataclass(frozen=True)
@@ -527,7 +530,14 @@ def get_automations(config: Mapping[str, object]) -> list[Automation]:
         policy = _automation_mapping(policy, f"{entry_path}.policy")
         _reject_unknown_automation_keys(
             policy,
-            {"concurrency", "output", "merge"},
+            {
+                "concurrency",
+                "output",
+                "merge",
+                "link-source-issue",
+                "include-factory-session",
+                "include-pi-resume",
+            },
             f"{entry_path}.policy",
             {"concurency": "concurrency"},
         )
@@ -570,6 +580,22 @@ def get_automations(config: Mapping[str, object]) -> list[Automation]:
             raise ConfigError(f"Automation '{name}' requires policy.merge: never")
         if policy.get("output", "draft-pr") != "draft-pr":
             raise ConfigError(f"Automation '{name}' requires policy.output: draft-pr")
+        public_policy: dict[str, bool] = {}
+        for key in (
+            "link-source-issue",
+            "include-factory-session",
+            "include-pi-resume",
+        ):
+            value = policy.get(key, True)
+            if not isinstance(value, bool):
+                raise ConfigError(f"Automation '{name}' requires boolean policy.{key}")
+            public_policy[key] = value
+        if not public_policy["link-source-issue"] and checkout.mode == "existing":
+            raise ConfigError(
+                f"Automation '{name}' requires target.checkout.mode "
+                "isolated-worktree or managed-worktree when "
+                "policy.link-source-issue is false"
+            )
         labels = source.get("labels", {})
         labels = _automation_mapping(labels, f"{entry_path}.source.labels")
         label_defaults = {
@@ -615,7 +641,11 @@ def get_automations(config: Mapping[str, object]) -> list[Automation]:
                     checkout=checkout,
                 ),
                 runner=PiRunnerConfig(skill=skill, timeout_seconds=timeout_seconds),
-                policy=AutomationPolicy(),
+                policy=AutomationPolicy(
+                    link_source_issue=public_policy["link-source-issue"],
+                    include_factory_session=public_policy["include-factory-session"],
+                    include_pi_resume=public_policy["include-pi-resume"],
+                ),
             )
         )
     return automations

--- a/tests/adapters/test_gh.py
+++ b/tests/adapters/test_gh.py
@@ -3,7 +3,12 @@ from pathlib import Path
 
 import pytest
 
-from groundskeeper.adapters.gh import GH_QUERY_TIMEOUT_SECONDS, GhClient, GhError
+from groundskeeper.adapters.gh import (
+    GH_BRANCH_PULL_REQUEST_LIMIT,
+    GH_QUERY_TIMEOUT_SECONDS,
+    GhClient,
+    GhError,
+)
 from groundskeeper.adapters.process import CommandResult
 from groundskeeper.domain.automation import GitHubIssueIdentity
 from groundskeeper.domain.task_contract import DependencyState, GitHubDependency
@@ -61,6 +66,23 @@ def _pr(
         "isDraft": draft,
         "state": state,
         "repository": {"nameWithOwner": repository},
+    }
+
+
+def _branch_pr(
+    url: str,
+    repository: str,
+    branch: str,
+    *,
+    draft: bool = True,
+    state: str = "OPEN",
+) -> dict[str, object]:
+    return {
+        "url": url,
+        "isDraft": draft,
+        "state": state,
+        "headRefName": branch,
+        "headRepository": {"nameWithOwner": repository},
     }
 
 
@@ -239,6 +261,102 @@ def test_reconciliation_reports_accepted_and_violating_coexistence() -> None:
 
     assert result.accepted_url == "https://pr/accepted"
     assert result.policy_violation is not None
+
+
+def test_branch_reconciliation_filters_exact_target_and_head_branch() -> None:
+    branch = "groundskeeper/task-abc123"
+    process = FakeProcess(
+        json.dumps(
+            [
+                _branch_pr("https://pr/other-repo", "other/repo", branch),
+                _branch_pr("https://pr/other-branch", "target/repo", "feature"),
+                _branch_pr("https://pr/exact", "target/repo", branch),
+            ]
+        )
+    )
+
+    result = GhClient(process, Path(".")).reconcile_branch_pull_requests(
+        "target/repo", branch
+    )
+
+    assert result.accepted_url == "https://pr/exact"
+    assert result.policy_violation is None
+    assert process.argv[:3] == ("gh", "pr", "list")
+    assert process.argv[process.argv.index("--repo") + 1] == "target/repo"
+    assert process.argv[process.argv.index("--head") + 1] == branch
+    assert process.argv[process.argv.index("--state") + 1] == "all"
+
+
+def test_branch_reconciliation_fails_closed_when_result_limit_is_reached() -> None:
+    branch = "groundskeeper/task-abc123"
+    payload = json.dumps(
+        [
+            _branch_pr(f"https://pr/{number}", "target/repo", branch)
+            for number in range(GH_BRANCH_PULL_REQUEST_LIMIT)
+        ]
+    )
+
+    with pytest.raises(GhError, match="reached the supported result limit"):
+        GhClient(FakeProcess(payload), Path(".")).reconcile_branch_pull_requests(
+            "target/repo", branch
+        )
+
+
+@pytest.mark.parametrize(
+    ("draft", "state", "expected"),
+    [
+        (False, "OPEN", "not a draft"),
+        (True, "CLOSED", "not open"),
+        (True, "MERGED", "not open"),
+    ],
+)
+def test_branch_reconciliation_rejects_non_draft_or_closed_pr(
+    draft: bool, state: str, expected: str
+) -> None:
+    branch = "groundskeeper/task-abc123"
+    process = FakeProcess(
+        json.dumps(
+            [
+                _branch_pr(
+                    "https://pr/invalid",
+                    "target/repo",
+                    branch,
+                    draft=draft,
+                    state=state,
+                )
+            ]
+        )
+    )
+
+    result = GhClient(process, Path(".")).reconcile_branch_pull_requests(
+        "target/repo", branch
+    )
+
+    assert result.policy_violation is not None
+    assert expected in result.policy_violation
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{}",
+        json.dumps(
+            [
+                {
+                    "url": "https://pr/incomplete",
+                    "isDraft": True,
+                    "state": "OPEN",
+                    "headRefName": "groundskeeper/task-abc123",
+                }
+            ]
+        ),
+    ],
+)
+def test_incomplete_branch_pull_request_payload_is_rejected(payload: str) -> None:
+    with pytest.raises(GhError):
+        GhClient(FakeProcess(payload), Path(".")).reconcile_branch_pull_requests(
+            "target/repo", "groundskeeper/task-abc123"
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/adapters/test_github_issues.py
+++ b/tests/adapters/test_github_issues.py
@@ -8,8 +8,9 @@ from groundskeeper.domain.automation import (
     AdmissionState,
     PullRequestReconciliation,
     TaskState,
+    automation_task_branch,
 )
-from groundskeeper.domain.config import GitHubIssuesSource
+from groundskeeper.domain.config import AutomationPolicy, GitHubIssuesSource
 from groundskeeper.domain.task_contract import DependencyState, GitHubDependency
 
 VALID_BODY = "## Factory Task\n\nSchema: 1\nKind: runnable\nMode: full\n\n## Dependencies\n\nNone\n"
@@ -41,6 +42,7 @@ class FakeGhClient:
         self.comments: list[tuple[int, str]] = []
         self.issue_repositories: list[str] = []
         self.pull_request_repositories: list[str] = []
+        self.pull_request_branches: list[tuple[str, str]] = []
 
     def list_issues(self, repository: str, labels: tuple[str, ...]) -> list[GhIssue]:
         self.issue_repositories.append(repository)
@@ -82,11 +84,17 @@ class FakeGhClient:
         self.pull_request_repositories.append(repository)
         return PullRequestReconciliation()
 
+    def reconcile_branch_pull_requests(
+        self, repository: str, branch: str
+    ) -> PullRequestReconciliation:
+        self.pull_request_branches.append((repository, branch))
+        return PullRequestReconciliation()
+
 
 def test_filters_untrusted_authors_and_claim_is_idempotent() -> None:
     client = FakeGhClient()
     source = GitHubIssuesSource("source/queue", ("alex",))
-    tracker = GitHubIssuesTracker(client, source, "target/repo")
+    tracker = GitHubIssuesTracker(client, source, "target/repo", AutomationPolicy())
     tasks = tracker.list_ready()
     assert [task.source_issue.number for task in tasks] == [1]
     assert tasks[0].source_issue.repository == "source/queue"
@@ -102,10 +110,31 @@ def test_filters_untrusted_authors_and_claim_is_idempotent() -> None:
     assert client.pull_request_repositories == ["target/repo"]
 
 
+def test_reconciliation_uses_task_branch_when_source_link_is_disabled() -> None:
+    client = FakeGhClient()
+    tracker = GitHubIssuesTracker(
+        client,
+        GitHubIssuesSource("source/queue", ("alex",)),
+        "target/repo",
+        AutomationPolicy(link_source_issue=False),
+    )
+    task = tracker.list_ready()[0]
+
+    tracker.reconcile_pull_requests(task)
+
+    assert client.pull_request_repositories == []
+    assert client.pull_request_branches == [
+        ("target/repo", automation_task_branch(task))
+    ]
+
+
 def test_claim_returns_freshly_relisted_issue_body() -> None:
     client = FakeGhClient()
     tracker = GitHubIssuesTracker(
-        client, GitHubIssuesSource("source/queue", ("alex",)), "target/repo"
+        client,
+        GitHubIssuesSource("source/queue", ("alex",)),
+        "target/repo",
+        AutomationPolicy(),
     )
     selected = tracker.list_ready()[0]
     changed_body = VALID_BODY.replace("Mode: full", "Mode: focused")
@@ -121,7 +150,10 @@ def test_claim_returns_freshly_relisted_issue_body() -> None:
 def test_claim_fails_if_post_mutation_snapshot_is_no_longer_running() -> None:
     client = FakeGhClient()
     tracker = GitHubIssuesTracker(
-        client, GitHubIssuesSource("source/queue", ("alex",)), "target/repo"
+        client,
+        GitHubIssuesSource("source/queue", ("alex",)),
+        "target/repo",
+        AutomationPolicy(),
     )
     selected = tracker.list_ready()[0]
     client.get_issue = lambda repository, issue: replace(  # type: ignore[method-assign]
@@ -137,7 +169,10 @@ def test_claim_fails_if_post_mutation_snapshot_is_no_longer_running() -> None:
 def test_refresh_rejects_closed_issue() -> None:
     client = FakeGhClient()
     tracker = GitHubIssuesTracker(
-        client, GitHubIssuesSource("source/queue", ("alex",)), "target/repo"
+        client,
+        GitHubIssuesSource("source/queue", ("alex",)),
+        "target/repo",
+        AutomationPolicy(),
     )
     running = replace(tracker.list_ready()[0], state=TaskState.RUNNING)
     client.get_issue = lambda repository, issue: replace(  # type: ignore[method-assign]
@@ -162,7 +197,10 @@ def test_lists_and_atomically_claims_deferred_work() -> None:
         )
     ]
     tracker = GitHubIssuesTracker(
-        client, GitHubIssuesSource("source/queue", ("alex",)), "target/repo"
+        client,
+        GitHubIssuesSource("source/queue", ("alex",)),
+        "target/repo",
+        AutomationPolicy(),
     )
 
     task = tracker.list_deferred()[0]
@@ -178,7 +216,10 @@ def test_lists_and_atomically_claims_deferred_work() -> None:
 def test_admission_blocks_tracking_and_unresolved_dependencies() -> None:
     client = FakeGhClient()
     tracker = GitHubIssuesTracker(
-        client, GitHubIssuesSource("source/queue", ("alex",)), "target/repo"
+        client,
+        GitHubIssuesSource("source/queue", ("alex",)),
+        "target/repo",
+        AutomationPolicy(),
     )
     tracking = replace(
         tracker.list_ready()[0],
@@ -221,6 +262,7 @@ def test_transition_to_deferred_uses_configured_label_and_ai_authored_comment() 
             deferred_label="queue:later",
         ),
         "target/repo",
+        AutomationPolicy(),
     )
     running = tracker.claim(tracker.list_ready()[0]).task
 

--- a/tests/adapters/test_pi.py
+++ b/tests/adapters/test_pi.py
@@ -142,6 +142,9 @@ def test_pi_runner_renders_normalized_task_context_with_typed_settings() -> None
     assert client.settings.timeout_seconds == 7200
     assert "POLICY_OUTPUT: draft-pr" in client.prompt
     assert "POLICY_MERGE: never" in client.prompt
+    assert "POLICY_LINK_SOURCE_ISSUE: true" in client.prompt
+    assert "POLICY_INCLUDE_FACTORY_SESSION: true" in client.prompt
+    assert "POLICY_INCLUDE_PI_RESUME: true" in client.prompt
     assert f"FACTORY_SESSION_ID: {client.settings.session_id}" in client.prompt
     assert "FACTORY_SESSION_NAME: gk-source-queue-3-to-target-repo" in client.prompt
     assert (
@@ -199,6 +202,45 @@ def test_same_repository_task_renders_short_closing_reference() -> None:
     _runner(client).run(_admitted(task))
 
     assert "FACTORY_CLOSING_REFERENCE: #3" in client.prompt
+
+
+def test_public_handoff_policy_omits_closing_reference() -> None:
+    policy = AutomationPolicy(
+        link_source_issue=False,
+        include_factory_session=False,
+        include_pi_resume=False,
+    )
+    renderer = AutomationSkillRenderer(_skill(), policy, AutomationCheckout())
+    task = AutomationTask(
+        "github",
+        "Fix it",
+        "Acceptance",
+        "https://issue/3",
+        "alex",
+        GitHubIssueIdentity("source/queue", 3),
+        "target/repo",
+        contract=_contract(),
+    )
+    settings = PiExecutionSettings(
+        session_id="session-id",
+        name="session-name",
+        timeout_seconds=7200,
+    )
+
+    prompt = renderer.render(
+        _admitted(task),
+        False,
+        settings,
+        TargetWorkspace(Path("/repos/dots"), None),
+    )
+
+    assert "POLICY_LINK_SOURCE_ISSUE: false" in prompt
+    assert "POLICY_INCLUDE_FACTORY_SESSION: false" in prompt
+    assert "POLICY_INCLUDE_PI_RESUME: false" in prompt
+    assert "FACTORY_CLOSING_REFERENCE:" not in prompt
+    assert "FACTORY_SESSION_ID: session-id" in prompt
+    assert "FACTORY_SESSION_NAME: session-name" in prompt
+    assert "FACTORY_RESUME_COMMAND: pi --session session-id" in prompt
 
 
 def test_admitted_task_rejects_mismatched_contract() -> None:

--- a/tests/cli/test_cli_automation.py
+++ b/tests/cli/test_cli_automation.py
@@ -110,6 +110,9 @@ def test_automation_list_json(tmp_path: Path) -> None:
                         "concurrency": 1,
                         "output": "draft-pr",
                         "merge": "never",
+                        "link_source_issue": True,
+                        "include_factory_session": True,
+                        "include_pi_resume": True,
                     },
                 }
             ]
@@ -229,6 +232,9 @@ def test_automation_show_and_validate_use_versioned_envelopes(
                     "concurrency": 1,
                     "output": "draft-pr",
                     "merge": "never",
+                    "link_source_issue": True,
+                    "include_factory_session": True,
+                    "include_pi_resume": True,
                 },
                 "skill": {
                     "name": "codex-code-review",

--- a/tests/domain/test_automation_config.py
+++ b/tests/domain/test_automation_config.py
@@ -47,6 +47,58 @@ def test_parses_explicit_source_and_target_automation() -> None:
     assert item.runner.approval == "allow"
     assert item.runner.session == "deterministic"
     assert item.runner.timeout_seconds == 7200
+    assert item.policy.link_source_issue is True
+    assert item.policy.include_factory_session is True
+    assert item.policy.include_pi_resume is True
+
+
+def test_parses_explicit_public_handoff_policy() -> None:
+    config = _valid_automation_config()
+    config["automations"]["daily"]["target"]["checkout"] = {  # type: ignore[index]
+        "mode": "isolated-worktree",
+        "base-ref": "origin/main",
+        "refresh": "fetch",
+    }
+    config["automations"]["daily"]["policy"].update(  # type: ignore[index,union-attr]
+        {
+            "link-source-issue": False,
+            "include-factory-session": False,
+            "include-pi-resume": False,
+        }
+    )
+
+    policy = get_automations(config)[0].policy
+
+    assert policy.link_source_issue is False
+    assert policy.include_factory_session is False
+    assert policy.include_pi_resume is False
+
+
+def test_private_handoff_requires_deterministic_checkout() -> None:
+    config = _valid_automation_config()
+    config["automations"]["daily"]["policy"]["link-source-issue"] = False  # type: ignore[index]
+
+    with pytest.raises(
+        ConfigError,
+        match=r"isolated-worktree or managed-worktree.*link-source-issue is false",
+    ):
+        get_automations(config)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "link-source-issue",
+        "include-factory-session",
+        "include-pi-resume",
+    ],
+)
+def test_public_handoff_policy_requires_boolean(key: str) -> None:
+    config = _valid_automation_config()
+    config["automations"]["daily"]["policy"][key] = "false"  # type: ignore[index]
+
+    with pytest.raises(ConfigError, match=rf"boolean policy\.{key}"):
+        get_automations(config)
 
 
 def test_parses_isolated_worktree_checkout_policy() -> None:

--- a/tests/e2e/test_e2e_commands.py
+++ b/tests/e2e/test_e2e_commands.py
@@ -323,6 +323,14 @@ class TestAutomationE2E:
         assert shown_automation["runner"]["skill"] == "issue-implementation"
         assert shown_automation["source"]["repository"] == "source/queue"
         assert shown_automation["target"]["repository"] == "target/repo"
+        assert shown_automation["policy"] == {
+            "concurrency": 1,
+            "output": "draft-pr",
+            "merge": "never",
+            "link_source_issue": True,
+            "include_factory_session": True,
+            "include_pi_resume": True,
+        }
         validated_automation = json.loads(validated.stdout)["data"]["automations"][0]
         assert validated_automation["source"]["repository"] == "source/queue"
         assert validated_automation["target"]["repository"] == "target/repo"
@@ -360,6 +368,13 @@ class TestAutomationE2E:
             "base-ref": "origin/main",
             "refresh": "none",
         }
+        config["automations"]["daily"]["policy"].update(
+            {
+                "link-source-issue": False,
+                "include-factory-session": False,
+                "include-pi-resume": False,
+            }
+        )
         config_path.write_text(yaml.safe_dump(config, sort_keys=False))
 
         validated = run_gk(
@@ -374,6 +389,14 @@ class TestAutomationE2E:
             "mode": "isolated-worktree",
             "base_ref": "origin/main",
             "refresh": "none",
+        }
+        assert json.loads(validated.stdout)["data"]["automations"][0]["policy"] == {
+            "concurrency": 1,
+            "output": "draft-pr",
+            "merge": "never",
+            "link_source_issue": False,
+            "include_factory_session": False,
+            "include_pi_resume": False,
         }
 
     def test_live_tick_fetches_immutable_base_without_modifying_dirty_donor(


### PR DESCRIPTION
## Summary

- Add exact policy booleans for source issue links, factory session identifiers, and Pi resume references.
- Default every field to `true` without aliases, migrations, or repository-based inference.
- Reconcile private handoffs by deterministic task branch and require isolated or managed checkout modes.
- Cover default and private modes with unit and installed-CLI E2E tests.

## Validation

- `mise run check` — 419 passed; lint, format, type, and 85% coverage green.
- Installed CLI E2E — 2 passed.
- Four-agent Codex review completed and findings addressed.