### PR TITLE
Keep private factory result links one-way

### DIFF
--- a/docs/config-and-skills.md
+++ b/docs/config-and-skills.md
@@ -34,7 +34,8 @@ Groundskeeper validates this policy and enforces the accepted-result
 postcondition: only an open draft pull request in the target repository reaches
 review. With `policy.link-source-issue: true`, Groundskeeper identifies that PR
 through GitHub's exact source-issue closing references. With it false,
-Groundskeeper identifies the PR through the deterministic automation branch.
+Groundskeeper identifies the PR through the deterministic configured task
+branch.
 It does not sandbox a user-authorized Pi process. An automation skill receives normalized
 `TASK_ID`, `TASK_TITLE`, `TASK_BODY`, `TASK_URL`, target `REPOSITORY`, typed
 `RECOVERY_CONTEXT`, `POLICY_CONCURRENCY`, `POLICY_OUTPUT`, `POLICY_MERGE`,
@@ -61,10 +62,12 @@ The three disclosure fields are strict booleans and default to `true`.
 `link-source-issue: false` tells the worker not to link or mention the source
 queue issue in the target PR and changes reconciliation to the deterministic
 task branch, so it requires `target.checkout.mode: isolated-worktree` or
-`managed-worktree`. The other fields tell the worker whether factory-session identity
-and the Pi resume reference may appear in the target PR. Groundskeeper still
-provides those values in execution context for recovery and may record them on
-the source-side factory issue.
+`managed-worktree`. Review transitions still record a clickable target PR on
+the source issue through GitHub's documented `redirect.github.com` host, which
+does not create a backlink on the target PR. The other fields tell the worker
+whether factory-session identity and the Pi resume reference may appear in the
+target PR. Groundskeeper still provides those values in execution context for
+recovery and may record them on the source-side factory issue.
 
 Every GitHub Issues automation task must begin with exactly these first two H2
 sections. The contract sections cannot contain comments or fenced examples:
@@ -113,6 +116,7 @@ target:
     mode: isolated-worktree
     base-ref: origin/main
     refresh: fetch
+    branch-prefix: changes/task
 ```
 
 When `checkout` is omitted, `mode: existing` preserves the original behavior
@@ -121,13 +125,21 @@ and Pi runs in `repository-path`. Both managed modes require an explicit
 creates a deterministic task worktree under the host state directory.
 `mode: managed-worktree` instead reuses `repository-path` itself. That path must
 be a linked worktree, initially clean and detached or already on a
-`groundskeeper/task-*` branch. A dirty task branch may be resumed, but
-Groundskeeper refuses to switch away from it. Primary checkouts and ordinary
-local branches are rejected. This mode is useful for large repositories whose
-disposable linked worktree already shares a populated local object store and
-working tree. Its `base-ref` must be a stable named ref such as `origin/main` or
-a full commit SHA. Checkout-relative expressions and Groundskeeper task refs are
-rejected because the managed worktree moves between task branches.
+configured task branch (`groundskeeper/task-*` by default). A dirty task branch
+may be resumed, but Groundskeeper refuses to switch away from it. Primary
+checkouts and ordinary local branches are rejected. This mode is useful for
+large repositories whose disposable linked worktree already shares a populated
+local object store and working tree. Its `base-ref` must be a stable named ref
+such as `origin/main` or a full commit SHA. Checkout-relative expressions and
+configured task refs are rejected because the managed worktree moves between
+task branches.
+
+`branch-prefix` defaults to `groundskeeper/task` and must remain stable while
+tasks are running, deferred, or awaiting review. Changing it is an explicit
+cutover: finish or close active task pull requests, preserve any worktree
+changes, and leave a managed worktree clean and detached before applying the
+new configuration. Groundskeeper does not search or resume branches under old
+prefixes.
 
 `refresh: none` resolves the locally available ref without network mutation.
 `refresh: fetch` requires an `origin/*` base and, for a live tick only, fetches
@@ -152,7 +164,7 @@ Task worktrees, their local branches, and pinned base refs are retained after a
 terminal transition so draft-PR review and deterministic recovery never lose
 local state. Groundskeeper currently performs no automatic garbage collection.
 Operators may remove a task worktree with normal `git worktree remove` and then
-delete its `groundskeeper/task-*` branch and `refs/groundskeeper/bases/*` ref
+delete its configured task branch and `refs/groundskeeper/bases/*` ref
 only after the task and pull request no longer need recovery. Automated,
 lock-protected retention policy remains future work.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -110,7 +110,7 @@ postcondition by transitioning to review only for an open draft pull request in
 the target repository. With `policy.link-source-issue: true`, it queries the
 exact source issue's documented GraphQL `closedByPullRequestsReferences`
 connection. With source linking disabled, it queries the deterministic
-Groundskeeper task branch; that mode requires an `isolated-worktree` or
+configured task branch; that mode requires an `isolated-worktree` or
 `managed-worktree` checkout. Both paths read repository identity, filter to the
 configured target, and fail closed on malformed results. Before worker
 dispatch, an accepted open draft reaches review; otherwise a non-draft, closed,

--- a/groundskeeper/adapters/github_issues.py
+++ b/groundskeeper/adapters/github_issues.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import replace
 
 from groundskeeper.adapters.gh import GhClient, GhIssue
@@ -16,7 +17,11 @@ from groundskeeper.domain.automation import (
     TaskState,
     automation_task_branch,
 )
-from groundskeeper.domain.config import AutomationPolicy, GitHubIssuesSource
+from groundskeeper.domain.config import (
+    AutomationCheckout,
+    AutomationPolicy,
+    GitHubIssuesSource,
+)
 from groundskeeper.domain.task_contract import (
     DependencyState,
     FactoryTaskKind,
@@ -32,11 +37,13 @@ class GitHubIssuesTracker:
         source: GitHubIssuesSource,
         target_repository: str,
         policy: AutomationPolicy,
+        checkout: AutomationCheckout,
     ) -> None:
         self._client = client
         self._source = source
         self._target_repository = target_repository
         self._policy = policy
+        self._checkout = checkout
 
     def list_ready(self) -> list[AutomationTask]:
         return self._list_in_state(self._source.ready_label, TaskState.READY)
@@ -149,8 +156,18 @@ class GitHubIssuesTracker:
         return ClaimResult(True, refreshed)
 
     def transition(
-        self, task: AutomationTask, state: TaskState, detail: str = ""
+        self,
+        task: AutomationTask,
+        state: TaskState,
+        detail: str = "",
+        *,
+        pull_request_url: str | None = None,
     ) -> None:
+        rendered_detail = self._source_comment_detail(
+            state,
+            detail,
+            pull_request_url=pull_request_url,
+        )
         target = {
             TaskState.REVIEW: self._source.review_label,
             TaskState.BLOCKED: self._source.blocked_label,
@@ -168,19 +185,58 @@ class GitHubIssuesTracker:
         self._client.replace_label(
             self._source.repository, task.source_issue.number, old, target
         )
-        if detail:
+        if rendered_detail:
             self._client.comment(
                 self._source.repository,
                 task.source_issue.number,
-                f"AI-authored factory update: {detail}",
+                f"AI-authored factory update: {rendered_detail}",
             )
+
+    def _source_comment_detail(
+        self,
+        state: TaskState,
+        detail: str,
+        *,
+        pull_request_url: str | None,
+    ) -> str:
+        """Render a clickable private result without creating a target backlink."""
+        if self._policy.link_source_issue:
+            return detail
+        target_pull_request = re.compile(
+            rf"https://github\.com/{re.escape(self._target_repository)}/pull/"
+            r"(?P<number>[1-9]\d*)",
+            re.IGNORECASE,
+        )
+        if state is TaskState.REVIEW:
+            typed_match = (
+                target_pull_request.fullmatch(pull_request_url)
+                if pull_request_url is not None
+                else None
+            )
+            detail_matches = list(target_pull_request.finditer(detail))
+            if (
+                typed_match is None
+                or len(detail_matches) != 1
+                or detail_matches[0].group("number") != typed_match.group("number")
+            ):
+                raise RuntimeError(
+                    "private review transition requires an exact target pull request URL"
+                )
+        return target_pull_request.sub(
+            lambda match: (
+                f"https://redirect.github.com/{self._target_repository}/pull/"
+                f"{match.group('number')}"
+            ),
+            detail,
+        )
 
     def reconcile_pull_requests(
         self, task: AutomationTask
     ) -> PullRequestReconciliation:
         if not self._policy.link_source_issue:
             return self._client.reconcile_branch_pull_requests(
-                task.target_repository, automation_task_branch(task)
+                task.target_repository,
+                automation_task_branch(task, self._checkout.branch_prefix),
             )
         return self._client.reconcile_pull_requests(
             task.target_repository, task.source_issue

--- a/groundskeeper/adapters/target_checkout.py
+++ b/groundskeeper/adapters/target_checkout.py
@@ -12,6 +12,7 @@ from groundskeeper.adapters.process import ProcessClient
 from groundskeeper.domain.automation import (
     AutomationTask,
     automation_task_branch,
+    automation_task_key,
     canonical_github_repository,
 )
 from groundskeeper.domain.config import AutomationCheckout
@@ -76,7 +77,9 @@ class TargetCheckoutManager:
         """Return a nonmutating reason this task cannot use the managed target."""
         if self._checkout.mode != "managed-worktree":
             return None
-        branch_ref = f"refs/heads/{automation_task_branch(task)}"
+        branch_ref = (
+            f"refs/heads/{automation_task_branch(task, self._checkout.branch_prefix)}"
+        )
         current_branch = _managed_worktree_branch(self._process, self._repository_path)
         status = self._process.run(
             ("git", "status", "--porcelain"),
@@ -107,8 +110,8 @@ class TargetCheckoutManager:
                 "isolated-worktree checkout has no resolved candidate base"
             )
 
-        branch = automation_task_branch(task)
-        task_key = branch.removeprefix("groundskeeper/task-")
+        branch = automation_task_branch(task, self._checkout.branch_prefix)
+        task_key = automation_task_key(task)
         target_key = hashlib.sha256(
             (
                 f"{self._expected_repository.casefold()}\0"
@@ -182,7 +185,11 @@ class TargetCheckoutManager:
         self, branch: str, branch_ref: str, base_ref: str
     ) -> TargetWorkspace:
         """Create or resume a task branch in one explicit disposable worktree."""
-        _validate_managed_worktree(self._process, self._repository_path)
+        _validate_managed_worktree(
+            self._process,
+            self._repository_path,
+            branch_prefix=self._checkout.branch_prefix,
+        )
         candidate_base = self._candidate_base_sha
         if candidate_base is None:
             raise TargetCheckoutError("managed target has no resolved candidate base")
@@ -217,7 +224,10 @@ class TargetCheckoutManager:
         )
         self._run_or_raise(argv, "could not prepare the managed target workspace")
         _validate_managed_worktree(
-            self._process, self._repository_path, expected_branch_ref=branch_ref
+            self._process,
+            self._repository_path,
+            branch_prefix=self._checkout.branch_prefix,
+            expected_branch_ref=branch_ref,
         )
         return TargetWorkspace(self._repository_path, pinned_base)
 
@@ -356,7 +366,9 @@ def validate_target_checkout(
     checkout = checkout or AutomationCheckout()
     _validate_target_repository(process, repository_path, expected_repository)
     if checkout.mode == "managed-worktree":
-        _validate_managed_worktree(process, repository_path)
+        _validate_managed_worktree(
+            process, repository_path, branch_prefix=checkout.branch_prefix
+        )
     return _validate_base_ref(process, repository_path, checkout)
 
 
@@ -369,7 +381,9 @@ def prepare_target_checkout(
     """Refresh and prove a live isolated-worktree donor before tracker access."""
     _validate_target_repository(process, repository_path, expected_repository)
     if checkout.mode == "managed-worktree":
-        _validate_managed_worktree(process, repository_path)
+        _validate_managed_worktree(
+            process, repository_path, branch_prefix=checkout.branch_prefix
+        )
     if (
         checkout.mode in {"isolated-worktree", "managed-worktree"}
         and checkout.refresh == "fetch"
@@ -457,6 +471,7 @@ def _validate_managed_worktree(
     process: ProcessClient,
     repository_path: Path,
     *,
+    branch_prefix: str = "groundskeeper/task",
     expected_branch_ref: str | None = None,
 ) -> None:
     """Require a linked disposable worktree with a safe current branch."""
@@ -487,14 +502,15 @@ def _validate_managed_worktree(
             "managed target must be a linked disposable worktree, not the primary checkout"
         )
     branch_ref = _managed_worktree_branch(process, repository_path)
+    task_branch_prefix = f"refs/heads/{branch_prefix}-"
     if expected_branch_ref is not None:
         if branch_ref != expected_branch_ref:
             raise TargetCheckoutError(
                 "managed target is not on its deterministic task branch"
             )
-    elif branch_ref and not branch_ref.startswith("refs/heads/groundskeeper/task-"):
+    elif branch_ref and not branch_ref.startswith(task_branch_prefix):
         raise TargetCheckoutError(
-            "managed target must be detached or on a Groundskeeper task branch"
+            "managed target must be detached or on a configured task branch"
         )
     status = process.run(
         ("git", "status", "--porcelain"),
@@ -503,7 +519,7 @@ def _validate_managed_worktree(
     )
     if not status.success:
         raise TargetCheckoutError("could not inspect managed target worktree")
-    if status.stdout and not branch_ref.startswith("refs/heads/groundskeeper/task-"):
+    if status.stdout and not branch_ref.startswith(task_branch_prefix):
         raise TargetCheckoutError("managed target worktree must be clean")
 
 

--- a/groundskeeper/automation.py
+++ b/groundskeeper/automation.py
@@ -249,7 +249,12 @@ class AutomationService:
     ) -> TickResult:
         """Record a review transition with available session handoff metadata."""
         detail = _result_detail(pull_request_url, result)
-        self._tracker.transition(task, TaskState.REVIEW, detail)
+        self._tracker.transition(
+            task,
+            TaskState.REVIEW,
+            detail,
+            pull_request_url=pull_request_url,
+        )
         return TickResult(
             name,
             "review",

--- a/groundskeeper/cli/main.py
+++ b/groundskeeper/cli/main.py
@@ -216,6 +216,7 @@ def _automation_target_summary(item: Automation) -> dict[str, object]:
             "mode": item.target.checkout.mode,
             "base_ref": item.target.checkout.base_ref,
             "refresh": item.target.checkout.refresh,
+            "branch_prefix": item.target.checkout.branch_prefix,
         },
     }
 
@@ -502,6 +503,7 @@ def automation_inspect(ctx: click.Context, name: str, json_output: bool) -> None
             definition.source,
             definition.target.repository,
             definition.policy,
+            definition.target.checkout,
         )
         tasks = [
             *tracker.list_running(),
@@ -609,6 +611,7 @@ def _execute_automation_tick(
             definition.source,
             definition.target.repository,
             definition.policy,
+            definition.target.checkout,
         )
         service = AutomationService(tracker, runner)
         return definition, service.tick(definition, dry_run=True)
@@ -633,6 +636,7 @@ def _execute_automation_tick(
             definition.source,
             definition.target.repository,
             definition.policy,
+            definition.target.checkout,
         )
         service = AutomationService(tracker, runner)
         return definition, service.tick(definition, dry_run=False)

--- a/groundskeeper/domain/automation.py
+++ b/groundskeeper/domain/automation.py
@@ -82,12 +82,18 @@ def automation_task_identity(task: AutomationTask) -> str:
     )
 
 
-def automation_task_branch(task: AutomationTask) -> str:
+def automation_task_key(task: AutomationTask) -> str:
+    """Return the deterministic opaque key shared by task-owned Git state."""
+    return hashlib.sha256(automation_task_identity(task).encode("utf-8")).hexdigest()[
+        :16
+    ]
+
+
+def automation_task_branch(
+    task: AutomationTask, branch_prefix: str = "groundskeeper/task"
+) -> str:
     """Return the deterministic target branch used to identify one task PR."""
-    task_key = hashlib.sha256(
-        automation_task_identity(task).encode("utf-8")
-    ).hexdigest()[:16]
-    return f"groundskeeper/task-{task_key}"
+    return f"{branch_prefix}-{automation_task_key(task)}"
 
 
 class AdmissionState(str, Enum):

--- a/groundskeeper/domain/config.py
+++ b/groundskeeper/domain/config.py
@@ -148,6 +148,7 @@ class AutomationCheckout:
     mode: Literal["existing", "isolated-worktree", "managed-worktree"] = "existing"
     base_ref: str | None = None
     refresh: Literal["none", "fetch"] = "none"
+    branch_prefix: str = "groundskeeper/task"
 
 
 @dataclass(frozen=True)
@@ -232,7 +233,7 @@ def _parse_automation_checkout(raw: object, entry_path: str) -> AutomationChecko
     checkout = _automation_mapping(raw, f"{entry_path}.target.checkout")
     _reject_unknown_automation_keys(
         checkout,
-        {"mode", "base-ref", "refresh"},
+        {"mode", "base-ref", "refresh", "branch-prefix"},
         f"{entry_path}.target.checkout",
     )
     mode = checkout.get("mode")
@@ -244,7 +245,7 @@ def _parse_automation_checkout(raw: object, entry_path: str) -> AutomationChecko
     if mode == "existing":
         if set(checkout) != {"mode"}:
             raise ConfigError(
-                "target.checkout base-ref and refresh are only valid for "
+                "target.checkout base-ref, refresh, and branch-prefix are only valid for "
                 "mode: isolated-worktree or managed-worktree"
             )
         return AutomationCheckout()
@@ -260,7 +261,15 @@ def _parse_automation_checkout(raw: object, entry_path: str) -> AutomationChecko
             f"Automation '{entry_path.removeprefix('automations.')}' "
             "requires non-empty target.checkout.base-ref"
         )
-    if mode == "managed-worktree" and not _is_stable_managed_base_ref(base_ref):
+    branch_prefix = checkout.get("branch-prefix", "groundskeeper/task")
+    if not isinstance(branch_prefix, str) or not _is_valid_branch_prefix(branch_prefix):
+        raise ConfigError(
+            f"Automation '{entry_path.removeprefix('automations.')}' "
+            "target.checkout.branch-prefix must be a valid Git branch prefix"
+        )
+    if mode == "managed-worktree" and not _is_stable_managed_base_ref(
+        base_ref, branch_prefix
+    ):
         raise ConfigError(
             "target.checkout.mode: managed-worktree requires a stable named "
             "base-ref or full commit SHA"
@@ -289,16 +298,40 @@ def _parse_automation_checkout(raw: object, entry_path: str) -> AutomationChecko
         mode=cast(Literal["isolated-worktree", "managed-worktree"], mode),
         base_ref=base_ref,
         refresh=cast(Literal["none", "fetch"], refresh),
+        branch_prefix=branch_prefix,
     )
 
 
-def _is_stable_managed_base_ref(value: str) -> bool:
+def _is_valid_branch_prefix(value: str) -> bool:
+    """Accept a strict Git branch prefix that remains valid after a task suffix."""
+    if (
+        not value
+        or value.startswith(("-", "/", "."))
+        or value.endswith(("/", "."))
+        or ".." in value
+        or "@{" in value
+        or "//" in value
+        or any(
+            char in " ~^:?*[\\" or ord(char) < 32 or ord(char) == 127 for char in value
+        )
+    ):
+        return False
+    return all(
+        part and not part.startswith(".") and not part.endswith(".lock")
+        for part in value.split("/")
+    )
+
+
+def _is_stable_managed_base_ref(
+    value: str, branch_prefix: str = "groundskeeper/task"
+) -> bool:
     """Reject checkout-relative revision expressions and task-owned refs."""
     if _COMMIT_SHA_RE.fullmatch(value):
         return True
-    if value in {"HEAD", "@"} or value.startswith("groundskeeper/task-"):
+    task_prefix = f"{branch_prefix}-"
+    if value in {"HEAD", "@"} or value.startswith(task_prefix):
         return False
-    if value.startswith("refs/heads/groundskeeper/task-"):
+    if value.startswith(f"refs/heads/{task_prefix}"):
         return False
     if (
         value.startswith("/")

--- a/groundskeeper/protocols.py
+++ b/groundskeeper/protocols.py
@@ -59,7 +59,12 @@ class Tracker(Protocol):
     def admit(self, task: AutomationTask) -> AdmissionResult: ...
     def claim(self, task: AutomationTask) -> ClaimResult: ...
     def transition(
-        self, task: AutomationTask, state: TaskState, detail: str = ""
+        self,
+        task: AutomationTask,
+        state: TaskState,
+        detail: str = "",
+        *,
+        pull_request_url: str | None = None,
     ) -> None: ...
     def reconcile_pull_requests(
         self, task: AutomationTask

--- a/tests/adapters/test_github_issues.py
+++ b/tests/adapters/test_github_issues.py
@@ -10,7 +10,11 @@ from groundskeeper.domain.automation import (
     TaskState,
     automation_task_branch,
 )
-from groundskeeper.domain.config import AutomationPolicy, GitHubIssuesSource
+from groundskeeper.domain.config import (
+    AutomationCheckout,
+    AutomationPolicy,
+    GitHubIssuesSource,
+)
 from groundskeeper.domain.task_contract import DependencyState, GitHubDependency
 
 VALID_BODY = "## Factory Task\n\nSchema: 1\nKind: runnable\nMode: full\n\n## Dependencies\n\nNone\n"
@@ -94,7 +98,13 @@ class FakeGhClient:
 def test_filters_untrusted_authors_and_claim_is_idempotent() -> None:
     client = FakeGhClient()
     source = GitHubIssuesSource("source/queue", ("alex",))
-    tracker = GitHubIssuesTracker(client, source, "target/repo", AutomationPolicy())
+    tracker = GitHubIssuesTracker(
+        client,
+        source,
+        "target/repo",
+        AutomationPolicy(),
+        AutomationCheckout(),
+    )
     tasks = tracker.list_ready()
     assert [task.source_issue.number for task in tasks] == [1]
     assert tasks[0].source_issue.repository == "source/queue"
@@ -117,6 +127,12 @@ def test_reconciliation_uses_task_branch_when_source_link_is_disabled() -> None:
         GitHubIssuesSource("source/queue", ("alex",)),
         "target/repo",
         AutomationPolicy(link_source_issue=False),
+        AutomationCheckout(
+            "isolated-worktree",
+            "origin/main",
+            "none",
+            "changes/task",
+        ),
     )
     task = tracker.list_ready()[0]
 
@@ -124,7 +140,7 @@ def test_reconciliation_uses_task_branch_when_source_link_is_disabled() -> None:
 
     assert client.pull_request_repositories == []
     assert client.pull_request_branches == [
-        ("target/repo", automation_task_branch(task))
+        ("target/repo", automation_task_branch(task, "changes/task"))
     ]
 
 
@@ -135,6 +151,7 @@ def test_claim_returns_freshly_relisted_issue_body() -> None:
         GitHubIssuesSource("source/queue", ("alex",)),
         "target/repo",
         AutomationPolicy(),
+        AutomationCheckout(),
     )
     selected = tracker.list_ready()[0]
     changed_body = VALID_BODY.replace("Mode: full", "Mode: focused")
@@ -154,6 +171,7 @@ def test_claim_fails_if_post_mutation_snapshot_is_no_longer_running() -> None:
         GitHubIssuesSource("source/queue", ("alex",)),
         "target/repo",
         AutomationPolicy(),
+        AutomationCheckout(),
     )
     selected = tracker.list_ready()[0]
     client.get_issue = lambda repository, issue: replace(  # type: ignore[method-assign]
@@ -173,6 +191,7 @@ def test_refresh_rejects_closed_issue() -> None:
         GitHubIssuesSource("source/queue", ("alex",)),
         "target/repo",
         AutomationPolicy(),
+        AutomationCheckout(),
     )
     running = replace(tracker.list_ready()[0], state=TaskState.RUNNING)
     client.get_issue = lambda repository, issue: replace(  # type: ignore[method-assign]
@@ -201,6 +220,7 @@ def test_lists_and_atomically_claims_deferred_work() -> None:
         GitHubIssuesSource("source/queue", ("alex",)),
         "target/repo",
         AutomationPolicy(),
+        AutomationCheckout(),
     )
 
     task = tracker.list_deferred()[0]
@@ -220,6 +240,7 @@ def test_admission_blocks_tracking_and_unresolved_dependencies() -> None:
         GitHubIssuesSource("source/queue", ("alex",)),
         "target/repo",
         AutomationPolicy(),
+        AutomationCheckout(),
     )
     tracking = replace(
         tracker.list_ready()[0],
@@ -263,6 +284,7 @@ def test_transition_to_deferred_uses_configured_label_and_ai_authored_comment() 
         ),
         "target/repo",
         AutomationPolicy(),
+        AutomationCheckout(),
     )
     running = tracker.claim(tracker.list_ready()[0]).task
 
@@ -270,3 +292,88 @@ def test_transition_to_deferred_uses_configured_label_and_ai_authored_comment() 
 
     assert client.labels[-1] == (1, "factory:running", "queue:later")
     assert client.comments == [(1, "AI-authored factory update: retry next tick")]
+
+
+def test_private_review_transition_uses_clickable_no_backlink_result_url() -> None:
+    client = FakeGhClient()
+    tracker = GitHubIssuesTracker(
+        client,
+        GitHubIssuesSource("source/queue", ("alex",)),
+        "target/repo",
+        AutomationPolicy(link_source_issue=False),
+        AutomationCheckout("isolated-worktree", "origin/main"),
+    )
+    running = tracker.claim(tracker.list_ready()[0]).task
+
+    tracker.transition(
+        running,
+        TaskState.REVIEW,
+        (
+            "https://github.com/TARGET/repo/pull/42\n\n"
+            "Factory session: `private-session`"
+        ),
+        pull_request_url="https://github.com/target/REPO/pull/42",
+    )
+
+    assert client.comments == [
+        (
+            1,
+            (
+                "AI-authored factory update: "
+                "https://redirect.github.com/target/repo/pull/42\n\n"
+                "Factory session: `private-session`"
+            ),
+        )
+    ]
+
+
+def test_private_policy_rewrites_target_pr_urls_in_blocked_comments() -> None:
+    client = FakeGhClient()
+    tracker = GitHubIssuesTracker(
+        client,
+        GitHubIssuesSource("source/queue", ("alex",)),
+        "target/repo",
+        AutomationPolicy(link_source_issue=False),
+        AutomationCheckout("isolated-worktree", "origin/main"),
+    )
+    running = tracker.claim(tracker.list_ready()[0]).task
+
+    tracker.transition(
+        running,
+        TaskState.BLOCKED,
+        "Closed pull request: https://github.com/TARGET/REPO/pull/42",
+    )
+
+    assert client.comments == [
+        (
+            1,
+            (
+                "AI-authored factory update: Closed pull request: "
+                "https://redirect.github.com/target/repo/pull/42"
+            ),
+        )
+    ]
+
+
+def test_private_review_requires_typed_target_pr_before_mutation() -> None:
+    client = FakeGhClient()
+    tracker = GitHubIssuesTracker(
+        client,
+        GitHubIssuesSource("source/queue", ("alex",)),
+        "target/repo",
+        AutomationPolicy(link_source_issue=False),
+        AutomationCheckout("isolated-worktree", "origin/main"),
+    )
+    running = tracker.claim(tracker.list_ready()[0]).task
+    labels_before = list(client.labels)
+
+    with pytest.raises(RuntimeError, match="exact target pull request URL"):
+        tracker.transition(
+            running,
+            TaskState.REVIEW,
+            "https://github.com/target/repo/pull/43",
+            pull_request_url="https://github.com/target/repo/pull/42",
+        )
+
+    assert client.labels == labels_before
+    assert client.comments == []

--- a/tests/adapters/test_target_checkout.py
+++ b/tests/adapters/test_target_checkout.py
@@ -249,7 +249,7 @@ def test_managed_checkout_reuses_disposable_worktree_without_second_checkout(
         check=True,
     )
 
-    checkout = AutomationCheckout("managed-worktree", "main", "none")
+    checkout = AutomationCheckout("managed-worktree", "main", "none", "changes/task")
     base_sha = validate_target_checkout(
         ProcessClient(), managed, "example/widgets", checkout
     )
@@ -282,7 +282,7 @@ def test_managed_checkout_reuses_disposable_worktree_without_second_checkout(
         capture_output=True,
         text=True,
     ).stdout.strip()
-    assert branch.startswith("groundskeeper/task-")
+    assert branch.startswith("changes/task-")
 
     wip = managed / "wip.txt"
     wip.write_text("resume me\n")

--- a/tests/cli/test_cli_automation.py
+++ b/tests/cli/test_cli_automation.py
@@ -97,6 +97,7 @@ def test_automation_list_json(tmp_path: Path) -> None:
                             "mode": "existing",
                             "base_ref": None,
                             "refresh": "none",
+                            "branch_prefix": "groundskeeper/task",
                         },
                     },
                     "runner": {
@@ -219,6 +220,7 @@ def test_automation_show_and_validate_use_versioned_envelopes(
                         "mode": "existing",
                         "base_ref": None,
                         "refresh": "none",
+                        "branch_prefix": "groundskeeper/task",
                     },
                 },
                 "runner": {
@@ -277,6 +279,7 @@ def test_inspect_full_versioned_payload(mock_tracker: object, tmp_path: Path) ->
                     "mode": "existing",
                     "base_ref": None,
                     "refresh": "none",
+                    "branch_prefix": "groundskeeper/task",
                 },
             },
             "tasks": [],
@@ -342,6 +345,7 @@ def test_tick_dry_run_omits_issue_body_from_json(
                     "mode": "existing",
                     "base_ref": None,
                     "refresh": "none",
+                    "branch_prefix": "groundskeeper/task",
                 },
             },
             "task": {

--- a/tests/domain/test_automation_config.py
+++ b/tests/domain/test_automation_config.py
@@ -43,6 +43,7 @@ def test_parses_explicit_source_and_target_automation() -> None:
     assert item.target.checkout.mode == "existing"
     assert item.target.checkout.base_ref is None
     assert item.target.checkout.refresh == "none"
+    assert item.target.checkout.branch_prefix == "groundskeeper/task"
     assert item.runner.skill == "issue-implementation"
     assert item.runner.approval == "allow"
     assert item.runner.session == "deterministic"
@@ -58,6 +59,7 @@ def test_parses_explicit_public_handoff_policy() -> None:
         "mode": "isolated-worktree",
         "base-ref": "origin/main",
         "refresh": "fetch",
+        "branch-prefix": "changes/task",
     }
     config["automations"]["daily"]["policy"].update(  # type: ignore[index,union-attr]
         {
@@ -107,6 +109,7 @@ def test_parses_isolated_worktree_checkout_policy() -> None:
         "mode": "isolated-worktree",
         "base-ref": "origin/main",
         "refresh": "fetch",
+        "branch-prefix": "changes/task",
     }
 
     checkout = get_automations(config)[0].target.checkout
@@ -114,6 +117,7 @@ def test_parses_isolated_worktree_checkout_policy() -> None:
     assert checkout.mode == "isolated-worktree"
     assert checkout.base_ref == "origin/main"
     assert checkout.refresh == "fetch"
+    assert checkout.branch_prefix == "changes/task"
 
 
 def test_parses_managed_worktree_checkout_policy() -> None:
@@ -138,6 +142,7 @@ def test_parses_managed_worktree_checkout_policy() -> None:
         (None, "target.checkout must be a mapping"),
         ({"mode": "unknown"}, "checkout.mode"),
         ({"mode": "existing", "base-ref": "origin/main"}, "only valid"),
+        ({"mode": "existing", "branch-prefix": "changes/task"}, "only valid"),
         ({"mode": "isolated-worktree"}, "checkout.base-ref"),
         *[
             (
@@ -174,6 +179,27 @@ def test_parses_managed_worktree_checkout_policy() -> None:
             },
             "checkout.*unknown key",
         ),
+        *[
+            (
+                {
+                    "mode": "isolated-worktree",
+                    "base-ref": "origin/main",
+                    "branch-prefix": branch_prefix,
+                },
+                "branch-prefix",
+            )
+            for branch_prefix in (
+                "",
+                "/changes/task",
+                "changes/task/",
+                "changes//task",
+                "changes/../task",
+                "changes/task.lock",
+                "changes task",
+                "changes~task",
+                "changes/task\x7f",
+            )
+        ],
     ],
 )
 def test_rejects_invalid_checkout_policy(

--- a/tests/e2e/test_e2e_commands.py
+++ b/tests/e2e/test_e2e_commands.py
@@ -367,6 +367,7 @@ class TestAutomationE2E:
             "mode": "isolated-worktree",
             "base-ref": "origin/main",
             "refresh": "none",
+            "branch-prefix": "changes/task",
         }
         config["automations"]["daily"]["policy"].update(
             {
@@ -389,6 +390,7 @@ class TestAutomationE2E:
             "mode": "isolated-worktree",
             "base_ref": "origin/main",
             "refresh": "none",
+            "branch_prefix": "changes/task",
         }
         assert json.loads(validated.stdout)["data"]["automations"][0]["policy"] == {
             "concurrency": 1,

--- a/tests/test_automation_service.py
+++ b/tests/test_automation_service.py
@@ -80,7 +80,12 @@ class FakeTracker:
         return ClaimResult(True, replace(task, state=TaskState.RUNNING))
 
     def transition(
-        self, task: AutomationTask, state: TaskState, detail: str = ""
+        self,
+        task: AutomationTask,
+        state: TaskState,
+        detail: str = "",
+        *,
+        pull_request_url: str | None = None,
     ) -> None:
         self.transitions.append((state, detail))
 


### PR DESCRIPTION
## Summary

- keep source-side target PR links clickable without creating reciprocal GitHub backlinks
- make managed task branch prefixes configurable independently from deterministic task identity
- fail closed when typed review URLs and reconciled target pull requests disagree

## Testing

- `mise run check`
- `mise run test:e2e`
- `mise run docs:build`