### PR TITLE
Expose automation authors in schema output

### DIFF
--- a/groundskeeper/cli/main.py
+++ b/groundskeeper/cli/main.py
@@ -173,6 +173,7 @@ def _automation_summary(
             "type": "github-issues",
             "repository": item.source.repository,
             "trusted_authors": list(item.source.trusted_authors),
+            "automation_authors": list(item.source.automation_authors),
             "labels": {
                 "ready": item.source.ready_label,
                 "running": item.source.running_label,

--- a/tests/cli/test_cli_automation.py
+++ b/tests/cli/test_cli_automation.py
@@ -83,6 +83,7 @@ def test_automation_list_json(tmp_path: Path) -> None:
                         "type": "github-issues",
                         "repository": "me/queue",
                         "trusted_authors": ["alex"],
+                        "automation_authors": ["alex"],
                         "labels": {
                             "ready": "factory:ready",
                             "running": "factory:running",
@@ -207,6 +208,7 @@ def test_automation_show_and_validate_use_versioned_envelopes(
                     "type": "github-issues",
                     "repository": "me/queue",
                     "trusted_authors": ["alex"],
+                    "automation_authors": ["alex"],
                     "labels": {
                         "ready": "factory:ready",
                         "running": "factory:running",


### PR DESCRIPTION
## Summary
- include `source.automation_authors` in stable schema-v2 automation summaries
- update list/show contract tests

## Why
Groundskeeper already requires and enforces `source.automation-authors`, but omitted it from `automation list/show --json`. The Coder work-factory M0 preflight must verify that security-sensitive author contract before installing a scheduler.

## Validation
- `uv run --frozen -m pytest tests/cli/test_cli_automation.py -q` (22 passed)
- focused Ruff lint/format
- `git diff --check`
